### PR TITLE
Add distribution lists to TestFlight upload

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/TestFlightPluginExtension.groovy
+++ b/plugin/src/main/groovy/org/openbakery/TestFlightPluginExtension.groovy
@@ -24,6 +24,7 @@ class TestFlightPluginExtension {
 	def String apiToken = null
 	def String teamToken = null
 	def String notes = "This build was uploaded using the gradle xcodePlugin"
+	def String distributionLists = null
 
 	private final Project project
 

--- a/plugin/src/main/groovy/org/openbakery/TestFlightUploadTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/TestFlightUploadTask.groovy
@@ -93,6 +93,7 @@ class TestFlightUploadTask extends DefaultTask {
 
 		println "api_token " + project.testflight.apiToken
 		println "team_token " + project.testflight.teamToken
+		println "distribution_lists" + project.testflight.distributionLists
 		println "notes " + project.testflight.notes
 		println "file " + ipaFile
 		println "dsym " + dSYMFile
@@ -101,6 +102,7 @@ class TestFlightUploadTask extends DefaultTask {
 		entity.addPart("api_token", new StringBody(project.testflight.apiToken))
 		entity.addPart("team_token", new StringBody(project.testflight.teamToken))
 		entity.addPart("notes", new StringBody(project.testflight.notes))
+		entity.addPart("distribution_lists", new StringBody(project.testflight.distributionLists))
 		entity.addPart("file", new FileBody(ipaFile))
 		entity.addPart("dsym", new FileBody(dSYMFile))
 


### PR DESCRIPTION
All it needs is to just turn on those properties. It's even documented in the REST call notes in the plugin config (probably from the TestFlight docs).
