### PR TITLE
Fix notifications in testflight

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/TestFlightUploadTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/TestFlightUploadTask.groovy
@@ -102,7 +102,10 @@ class TestFlightUploadTask extends DefaultTask {
 		entity.addPart("api_token", new StringBody(project.testflight.apiToken))
 		entity.addPart("team_token", new StringBody(project.testflight.teamToken))
 		entity.addPart("notes", new StringBody(project.testflight.notes))
-		entity.addPart("distribution_lists", new StringBody(project.testflight.distributionLists))
+		if (project.testflight.distributionLists != null){
+			entity.addPart("distribution_lists", new StringBody(project.testflight.distributionLists))
+			entity.addPart("notify", new StringBody("True"))
+		}
 		entity.addPart("file", new FileBody(ipaFile))
 		entity.addPart("dsym", new FileBody(dSYMFile))
 


### PR DESCRIPTION
Looks like sending notifications still not taking with testflight. The "Notify" flag needs to be set. Conditionally adding it if notes are supplied.
