### PR TITLE
Fixes to run Xcode build w/o resigning the app directory contents.

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/ProvisioningCleanupTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/ProvisioningCleanupTask.groovy
@@ -27,6 +27,10 @@ class ProvisioningCleanupTask extends AbstractXcodeTask {
 
 	@TaskAction
 	def clean() {
+        if (!project.xcodebuild.signing.mobileProvisionDestinationRoot.exists()) {
+            println "Provisioning cleanup skipped because the destination directory does not exit"
+            return
+        }
 
 		println "deleting " + project.xcodebuild.signing.mobileProvisionDestinationRoot
 		project.xcodebuild.signing.mobileProvisionDestinationRoot.deleteDir()

--- a/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
@@ -237,7 +237,13 @@ class XcodePlugin implements Plugin<Project> {
 
 		xcodebuild.dependsOn(project.tasks.'keychain-create')
 		xcodebuild.dependsOn(project.tasks.'provisioning-install')
-		xcodebuild.dependsOn(infoplistModify)
+
+        if (project.infoplist.bundleIdentifier != null
+                || project.infoplist.bundleIdentifierSuffix != null
+                || project.infoplist.versionSuffix != null)
+        {
+            xcodebuild.dependsOn(infoplistModify)
+        }
 
 		Task codesign = project.tasks.'codesign'
 		archive.dependsOn(codesign)


### PR DESCRIPTION
Some changes were required in order to make the plug-in work for our project.

**Dependency on infoplistModify is added to xcodebuild only when
infoplist settings are defined.**

Now dependency to _infoplist-modify_ task is added to _xcodebuild_ task only if there is infoplist configuration defined in the project. GitHub history shows that it used to work like that but then this logic was removed.

We need it for a reason not directly related to code signing. _INFOPLIST_FILE_ property is defined as _$(SRCROOT)/ProjectName/SupportingFiles/ProjectName-Info.plist_ in our project. _InfoPlistModifyTask_ does not resolve the _SRCROOT_ variable and hence fails to read the file.

This problem can be solved by using the following command to read project settings:
`xcodebuild -showBuildSettings|grep INFOPLIST_FILE`

We decided that it is more reasonable to just skip the _InfoPlistModify_ task because we don't need any changes in that file.

**ProvisioningCleanup now checks if directory exists before removing it.**

_ProvisioningInstallTask_ is skipped when mobileProvisionURI is not defined. ProvisioningCleanup does not find a directory to remove and fails. Now it just reports that directory does not exists and skips the removal.
