### PR TITLE
Catching upstream bug in Groovy or Java that causes an index out of boun...

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/CommandRunner.groovy
+++ b/plugin/src/main/groovy/org/openbakery/CommandRunner.groovy
@@ -42,15 +42,18 @@ class CommandRunner {
 			env.putAll(environment)
 		}
 		def process = processBuilder.start()
-		process.inputStream.eachLine {
-			println it
-			if (resultStringBuilder != null) {
-				if (resultStringBuilder.length() > 0) {
-					resultStringBuilder.append("\n");
-				}
-				resultStringBuilder.append(it);
-			}
-		}
+                process.inputStream.eachLine {
+                        println it
+                        if (resultStringBuilder != null) {
+                                if (resultStringBuilder.length() > 0) {
+                                        resultStringBuilder.append("\n");
+                                }
+                                try{
+                                                resultStringBuilder.append(it);
+                                        
+                                        }catch (Error E){}
+                        }
+                }
 		process.waitFor()
 		if (process.exitValue() > 0) {
 			throw new CommandRunnerException("Command failed to run: " + commandListToString(commandList))


### PR DESCRIPTION
...ds error.

Due to a bug in Groovy or Java some builds cause an IndexOutOfBounds exception. (Issue #34)

This catch block prevents build breakage due to this non critical error.
