### PR TITLE
Pull request for fix for issue #64

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/AbstractXcodeBuildTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/AbstractXcodeBuildTask.groovy
@@ -59,7 +59,7 @@ abstract class AbstractXcodeBuildTask extends DefaultTask {
 		}
 
 		if (project.xcodebuild.sdk.startsWith("iphoneos") && project.xcodebuild.signing != null && project.xcodebuild.signing.identity != null) {
-			commandList.add("CODE_SIGN_IDENTITY=" + project.xcodebuild.signing.identity)
+			commandList.add('CODE_SIGN_IDENTITY="' + project.xcodebuild.signing.identity + '"')
 		}
 
 		if (project.xcodebuild.arch != null) {
@@ -116,7 +116,7 @@ abstract class AbstractXcodeBuildTask extends DefaultTask {
 		}
 
 		if (project.xcodebuild.sdk.startsWith("iphoneos") && project.xcodebuild.signing.keychainPathInternal.exists()) {
-			commandList.add('OTHER_CODE_SIGN_FLAGS=--keychain ' + project.xcodebuild.signing.keychainPathInternal.path);
+			commandList.add('OTHER_CODE_SIGN_FLAGS="--keychain ' + project.xcodebuild.signing.keychainPathInternal.path + '"');
 		}
 
 		return commandList;


### PR DESCRIPTION
I had the same errors as ones described in issue #64 - seems like the issue is with missing quotes around the code signing arguments to xcodebuild
- added wrapper double quotes around CODE_SIGN_IDENTITY so that spaces in identity parameter doesn't trip up build
- added wrapper double quotes around OTHER_CODE_SIGN_FLAGS, xcodebuild trips up without quotes
