### PR TITLE
Common task name prefix support

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
@@ -70,9 +70,22 @@ class XcodePlugin implements Plugin<Project> {
 	public static final String COVERAGE_GROUP_NAME = "Coverage"
 	public static final String COCOAPODS_GROUP_NAME = "Cocoapods"
 
-	public static final String BUILD_TASK_NAME = "build";
-	public static final String TEST_TASK_NAME = "test"
-	public static final String ARCHIVE_TASK_NAME = "archive"
+	private static String INTERNAL_BUILD_TASK_NAME = "build"
+	private static String INTERNAL_TEST_TASK_NAME = "test"
+	private static String INTERNAL_ARCHIVE_TASK_NAME = "archive"
+
+	public static getBuildTaskName() {
+		return INTERNAL_BUILD_TASK_NAME
+	}
+
+	public static getTestTaskName() {
+		return INTERNAL_TEST_TASK_NAME
+	}
+
+	public static getArchiveTaskName() {
+		return INTERNAL_ARCHIVE_TASK_NAME
+	}
+
 	public static final String LIST_SIMULATORS_TASK_NAME = "list-simulators"
 	public static final String XCODE_BUILD_TASK_NAME = "xcodebuild"
 	public static final String XCODE_CLEAN_TASK_NAME = "xcodebuild-clean"
@@ -115,6 +128,8 @@ class XcodePlugin implements Plugin<Project> {
 
 		System.setProperty("java.awt.headless", "true");
 
+		configureTaskNames(project)
+
 		configureExtensions(project)
 		configureClean(project)
 		configureBuild(project)
@@ -137,6 +152,21 @@ class XcodePlugin implements Plugin<Project> {
 		configureProperties(project)
 	}
 
+	void configureTaskNames(Project project) {
+		if (!project.hasProperty('xcodePluginPrefix')) {
+			return
+		}
+
+		INTERNAL_BUILD_TASK_NAME = ensurePrefix(getBuildTaskName(), project.xcodePluginPrefix)
+		INTERNAL_TEST_TASK_NAME = ensurePrefix(getTestTaskName(), project.xcodePluginPrefix)
+		INTERNAL_ARCHIVE_TASK_NAME = ensurePrefix(getArchiveTaskName(), project.xcodePluginPrefix)
+	}
+
+	private static String ensurePrefix(String value, String prefix) {
+		if (!value.startsWith(prefix)) {
+			return prefix + value.capitalize()
+		}
+	}
 
 	void configureProperties(Project project) {
 
@@ -348,7 +378,7 @@ class XcodePlugin implements Plugin<Project> {
 	}
 
 	private void configureBuild(Project project) {
-		XcodeBuildTask buildTask = project.getTasks().create(BUILD_TASK_NAME, XcodeBuildTask.class);
+		XcodeBuildTask buildTask = project.getTasks().create(getBuildTaskName(), XcodeBuildTask.class);
 		buildTask.setGroup(BasePlugin.BUILD_GROUP);
 		buildTask.dependsOn(BasePlugin.ASSEMBLE_TASK_NAME);
 
@@ -368,7 +398,7 @@ class XcodePlugin implements Plugin<Project> {
 	}
 
 	private void configureArchive(Project project) {
-		XcodeBuildArchiveTask xcodeBuildArchiveTask = project.getTasks().create(ARCHIVE_TASK_NAME, XcodeBuildArchiveTask.class);
+		XcodeBuildArchiveTask xcodeBuildArchiveTask = project.getTasks().create(getArchiveTaskName(), XcodeBuildArchiveTask.class);
 		xcodeBuildArchiveTask.setGroup(XCODE_GROUP_NAME);
 
 		//xcodeBuildArchiveTask.dependsOn(project.getTasks().getByName(BasePlugin.CLEAN_TASK_NAME));
@@ -382,7 +412,7 @@ class XcodePlugin implements Plugin<Project> {
 	private void configureHockeyKit(Project project) {
 		project.task(HOCKEYKIT_MANIFEST_TASK_NAME, type: HockeyKitManifestTask, group: HOCKEYKIT_GROUP_NAME)
 		HockeyKitArchiveTask hockeyKitArchiveTask = project.task(HOCKEYKIT_ARCHIVE_TASK_NAME, type: HockeyKitArchiveTask, group: HOCKEYKIT_GROUP_NAME)
-		hockeyKitArchiveTask.dependsOn(ARCHIVE_TASK_NAME)
+		hockeyKitArchiveTask.dependsOn(getArchiveTaskName())
 		project.task(HOCKEYKIT_NOTES_TASK_NAME, type: HockeyKitReleaseNotesTask, group: HOCKEYKIT_GROUP_NAME)
 		project.task(HOCKEYKIT_IMAGE_TASK_NAME, type: HockeyKitImageTask, group: HOCKEYKIT_GROUP_NAME)
 		project.task(HOCKEYKIT_CLEAN_TASK_NAME, type: HockeyKitCleanTask, group: HOCKEYKIT_GROUP_NAME)
@@ -397,7 +427,7 @@ class XcodePlugin implements Plugin<Project> {
 	}
 
 	private void configureTest(Project project) {
-		project.task(TEST_TASK_NAME, type: XcodeTestTask, group: XCODE_GROUP_NAME)
+		project.task(getTestTaskName(), type: XcodeTestTask, group: XCODE_GROUP_NAME)
 
 	}
 
@@ -483,10 +513,10 @@ class XcodePlugin implements Plugin<Project> {
 	}
 
 	private void addDependencyToBuild(Project project, Task task) {
-		XcodeBuildTask buildTask = project.getTasks().getByName(BUILD_TASK_NAME)
+		XcodeBuildTask buildTask = project.getTasks().getByName(getBuildTaskName())
 		buildTask.dependsOn(task)
 
-		XcodeTestTask testTask = project.getTasks().getByName(TEST_TASK_NAME)
+		XcodeTestTask testTask = project.getTasks().getByName(getTestTaskName())
 		testTask.dependsOn(task)
 	}
 }

--- a/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
@@ -70,9 +70,9 @@ class XcodePlugin implements Plugin<Project> {
 	public static final String COVERAGE_GROUP_NAME = "Coverage"
 	public static final String COCOAPODS_GROUP_NAME = "Cocoapods"
 
-	public static final String BUILD_TASK_NAME = "build";
-	public static final String TEST_TASK_NAME = "test"
-	public static final String ARCHIVE_TASK_NAME = "archive"
+	public static final String BUILD_TASK_NAME = "build-xcode"
+	public static final String TEST_TASK_NAME = "test-xcode"
+	public static final String ARCHIVE_TASK_NAME = "archive-xcode"
 	public static final String LIST_SIMULATORS_TASK_NAME = "list-simulators"
 	public static final String XCODE_BUILD_TASK_NAME = "xcodebuild"
 	public static final String XCODE_CLEAN_TASK_NAME = "xcodebuild-clean"

--- a/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
@@ -70,22 +70,9 @@ class XcodePlugin implements Plugin<Project> {
 	public static final String COVERAGE_GROUP_NAME = "Coverage"
 	public static final String COCOAPODS_GROUP_NAME = "Cocoapods"
 
-	private static String INTERNAL_BUILD_TASK_NAME = "build"
-	private static String INTERNAL_TEST_TASK_NAME = "test"
-	private static String INTERNAL_ARCHIVE_TASK_NAME = "archive"
-
-	public static getBuildTaskName() {
-		return INTERNAL_BUILD_TASK_NAME
-	}
-
-	public static getTestTaskName() {
-		return INTERNAL_TEST_TASK_NAME
-	}
-
-	public static getArchiveTaskName() {
-		return INTERNAL_ARCHIVE_TASK_NAME
-	}
-
+	public static final String BUILD_TASK_NAME = "build";
+	public static final String TEST_TASK_NAME = "test"
+	public static final String ARCHIVE_TASK_NAME = "archive"
 	public static final String LIST_SIMULATORS_TASK_NAME = "list-simulators"
 	public static final String XCODE_BUILD_TASK_NAME = "xcodebuild"
 	public static final String XCODE_CLEAN_TASK_NAME = "xcodebuild-clean"
@@ -128,8 +115,6 @@ class XcodePlugin implements Plugin<Project> {
 
 		System.setProperty("java.awt.headless", "true");
 
-		configureTaskNames(project)
-
 		configureExtensions(project)
 		configureClean(project)
 		configureBuild(project)
@@ -152,21 +137,6 @@ class XcodePlugin implements Plugin<Project> {
 		configureProperties(project)
 	}
 
-	void configureTaskNames(Project project) {
-		if (!project.hasProperty('xcodePluginPrefix')) {
-			return
-		}
-
-		INTERNAL_BUILD_TASK_NAME = ensurePrefix(getBuildTaskName(), project.xcodePluginPrefix)
-		INTERNAL_TEST_TASK_NAME = ensurePrefix(getTestTaskName(), project.xcodePluginPrefix)
-		INTERNAL_ARCHIVE_TASK_NAME = ensurePrefix(getArchiveTaskName(), project.xcodePluginPrefix)
-	}
-
-	private static String ensurePrefix(String value, String prefix) {
-		if (!value.startsWith(prefix)) {
-			return prefix + value.capitalize()
-		}
-	}
 
 	void configureProperties(Project project) {
 
@@ -378,7 +348,7 @@ class XcodePlugin implements Plugin<Project> {
 	}
 
 	private void configureBuild(Project project) {
-		XcodeBuildTask buildTask = project.getTasks().create(getBuildTaskName(), XcodeBuildTask.class);
+		XcodeBuildTask buildTask = project.getTasks().create(BUILD_TASK_NAME, XcodeBuildTask.class);
 		buildTask.setGroup(BasePlugin.BUILD_GROUP);
 		buildTask.dependsOn(BasePlugin.ASSEMBLE_TASK_NAME);
 
@@ -398,7 +368,7 @@ class XcodePlugin implements Plugin<Project> {
 	}
 
 	private void configureArchive(Project project) {
-		XcodeBuildArchiveTask xcodeBuildArchiveTask = project.getTasks().create(getArchiveTaskName(), XcodeBuildArchiveTask.class);
+		XcodeBuildArchiveTask xcodeBuildArchiveTask = project.getTasks().create(ARCHIVE_TASK_NAME, XcodeBuildArchiveTask.class);
 		xcodeBuildArchiveTask.setGroup(XCODE_GROUP_NAME);
 
 		//xcodeBuildArchiveTask.dependsOn(project.getTasks().getByName(BasePlugin.CLEAN_TASK_NAME));
@@ -412,7 +382,7 @@ class XcodePlugin implements Plugin<Project> {
 	private void configureHockeyKit(Project project) {
 		project.task(HOCKEYKIT_MANIFEST_TASK_NAME, type: HockeyKitManifestTask, group: HOCKEYKIT_GROUP_NAME)
 		HockeyKitArchiveTask hockeyKitArchiveTask = project.task(HOCKEYKIT_ARCHIVE_TASK_NAME, type: HockeyKitArchiveTask, group: HOCKEYKIT_GROUP_NAME)
-		hockeyKitArchiveTask.dependsOn(getArchiveTaskName())
+		hockeyKitArchiveTask.dependsOn(ARCHIVE_TASK_NAME)
 		project.task(HOCKEYKIT_NOTES_TASK_NAME, type: HockeyKitReleaseNotesTask, group: HOCKEYKIT_GROUP_NAME)
 		project.task(HOCKEYKIT_IMAGE_TASK_NAME, type: HockeyKitImageTask, group: HOCKEYKIT_GROUP_NAME)
 		project.task(HOCKEYKIT_CLEAN_TASK_NAME, type: HockeyKitCleanTask, group: HOCKEYKIT_GROUP_NAME)
@@ -427,7 +397,7 @@ class XcodePlugin implements Plugin<Project> {
 	}
 
 	private void configureTest(Project project) {
-		project.task(getTestTaskName(), type: XcodeTestTask, group: XCODE_GROUP_NAME)
+		project.task(TEST_TASK_NAME, type: XcodeTestTask, group: XCODE_GROUP_NAME)
 
 	}
 
@@ -513,10 +483,10 @@ class XcodePlugin implements Plugin<Project> {
 	}
 
 	private void addDependencyToBuild(Project project, Task task) {
-		XcodeBuildTask buildTask = project.getTasks().getByName(getBuildTaskName())
+		XcodeBuildTask buildTask = project.getTasks().getByName(BUILD_TASK_NAME)
 		buildTask.dependsOn(task)
 
-		XcodeTestTask testTask = project.getTasks().getByName(getTestTaskName())
+		XcodeTestTask testTask = project.getTasks().getByName(TEST_TASK_NAME)
 		testTask.dependsOn(task)
 	}
 }

--- a/plugin/src/test/groovy/org/openbakery/XcodeBuildTaskTest.groovy
+++ b/plugin/src/test/groovy/org/openbakery/XcodeBuildTaskTest.groovy
@@ -45,7 +45,7 @@ class XcodeBuildTaskTest {
 		projectDir = project.projectDir.absolutePath
 		project.apply plugin: org.openbakery.XcodePlugin
 
-		xcodeBuildTask = project.getTasks().getByPath('build')
+		xcodeBuildTask = project.getTasks().getByPath('build-xcode')
 		xcodeBuildTask.setProperty("commandRunner", commandRunnerMock)
 
 		expectedCommandList?.clear()

--- a/plugin/src/test/groovy/org/openbakery/XcodePluginTest.groovy
+++ b/plugin/src/test/groovy/org/openbakery/XcodePluginTest.groovy
@@ -48,7 +48,7 @@ class XcodePluginTest {
 
 	@Test
 	void contain_task_archive() {
-		assert project.tasks.findByName('archive') instanceof XcodeBuildArchiveTask
+		assert project.tasks.findByName('archive-xcode') instanceof XcodeBuildArchiveTask
 	}
 
 	@Test
@@ -78,7 +78,7 @@ class XcodePluginTest {
 
 	@Test
 	void contain_task_xcodebuild() {
-		assert project.tasks.findByName('build') instanceof XcodeBuildTask
+		assert project.tasks.findByName('build-xcode') instanceof XcodeBuildTask
 	}
 
 	/* TODO clarify if makes sense to exclude deploy tasks into another xcodeplugin?

--- a/plugin/src/test/groovy/org/openbakery/XcodeTestTaskTest.groovy
+++ b/plugin/src/test/groovy/org/openbakery/XcodeTestTaskTest.groovy
@@ -35,7 +35,7 @@ class XcodeTestTaskTest {
 		project.apply plugin: org.openbakery.XcodePlugin
 
 
-		xcodeTestTask = project.tasks.findByName('test')
+		xcodeTestTask = project.tasks.findByName('test-xcode')
 
 		xcodeTestTask.setOutputDirectory(new File("build/test"));
 


### PR DESCRIPTION
Common task names like build, test and archive are used in many Gradle plugins.
Task names have to be unique, therefore such plugins cannot be used together in the
same project.

To solve this problem a new xcodePluginPrefix property is added to the
plugin to set the prefix of the common task names. This property has to be set in the
project before applying the Xcode plugin.