### PR TITLE
Make keychain argument to OTHER_CODE_SIGN_FLAGS space-less with a '=' ch...

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/AbstractXcodeBuildTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/AbstractXcodeBuildTask.groovy
@@ -82,7 +82,7 @@ abstract class AbstractXcodeBuildTask extends DefaultTask {
 
 
 		if (project.xcodebuild.sdk.startsWith("iphoneos") && project.xcodebuild.signing.keychainPathInternal.exists()) {
-			commandList.add('OTHER_CODE_SIGN_FLAGS=--keychain ' + project.xcodebuild.signing.keychainPathInternal.path);
+			commandList.add('OTHER_CODE_SIGN_FLAGS=--keychain=' + project.xcodebuild.signing.keychainPathInternal.path);
 		}
 
 


### PR DESCRIPTION
...aracter to avoid xcodebuild intepreting the argument value as a build action. Fixes issue #103 
