### PR TITLE
custom keychain timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ xcodebuild Parameters:
 
 		Note: Make sure that _/usr/bin/codesign_ is allowed to access the certificate in the keychain that is needed to sign.
 
+    * _timeout_ - A custom timeout before the keychain automatically locks, in seconds.  Set this to be longer than your build time if you are getting a prompt for the keychain password.
+
+        default value: empty
 
 * _destination_ * - destination configuration, that is used for the unit test execution
 

--- a/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
@@ -229,6 +229,9 @@ class XcodePlugin implements Plugin<Project> {
 			if (project.hasProperty('xcodebuild.signing.keychainPassword')) {
 				project.xcodebuild.signing.keychainPassword = project['signing.keychainPassword']
 			}
+			if (project.hasProperty('xcodebuild.signing.timeout')) {
+				project.xcodebuild.signing.timeout = project['signing.timeout']
+			}
 
 			if (project.hasProperty('xcodebuild.additionalParameters')) {
 				project.xcodebuild.additionalParameters = project['xcodebuild.additionalParameters']

--- a/plugin/src/main/groovy/org/openbakery/signing/KeychainCreateTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/signing/KeychainCreateTask.groovy
@@ -73,6 +73,11 @@ class KeychainCreateTask extends AbstractKeychainTask {
 			keychainList.add(keychainPath)
 			setKeychainList(keychainList)
 		}
+
+		// Set a custom timeout on the keychain if requested
+		if (project.xcodebuild.signing.timeout != null) {
+			commandRunner.run(["security", "-v", "set-keychain-settings", "-lut", project.xcodebuild.signing.timeout.toString(), keychainPath])
+		}
 	}
 
 

--- a/plugin/src/main/groovy/org/openbakery/signing/Signing.groovy
+++ b/plugin/src/main/groovy/org/openbakery/signing/Signing.groovy
@@ -18,7 +18,7 @@ class Signing {
 	String mobileProvisionURI
 	String keychainPassword = "This_is_the_default_keychain_password"
 	File keychain
-
+	Integer timeout
 
 
 	/**


### PR DESCRIPTION
Adds an option "timeout" integer to the signing section.  The timeout is applied to the keychain if specified.  This allows builds that take longer than the standard keychain lock timeout to complete successfully without prompting for the keychain password.

Fixes this issue for me: https://github.com/openbakery/gradle-xcodePlugin/issues/91
