### PR TITLE
Feature/testfight widgets

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/AbstractDistributeTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/AbstractDistributeTask.groovy
@@ -95,9 +95,6 @@ class AbstractDistributeTask extends AbstractXcodeTask {
 	void createDsymZip(File outputDirectory) {
 
 		def ant = new AntBuilder()
-//		ant.zip(destfile: getDsymZipFile(outputDirectory).absolutePath,
-//						basedir: project.xcodebuild.getOutputPath().absolutePath,
-//						includes: "*dSYM*/**")
         ant.zip(destfile: getDsymZipFile(outputDirectory).absolutePath,
                 basedir: project.xcodebuild.getOutputPath().absolutePath,
                 includes: project.xcodebuild.bundleName + ".app.dSYM*/**")

--- a/plugin/src/main/groovy/org/openbakery/AbstractDistributeTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/AbstractDistributeTask.groovy
@@ -95,9 +95,9 @@ class AbstractDistributeTask extends AbstractXcodeTask {
 	void createDsymZip(File outputDirectory) {
 
 		def ant = new AntBuilder()
-        ant.zip(destfile: getDsymZipFile(outputDirectory).absolutePath,
-                basedir: project.xcodebuild.getOutputPath().absolutePath,
-                includes: project.xcodebuild.bundleName + ".app.dSYM*/**")
+		ant.zip(destfile: getDsymZipFile(outputDirectory).absolutePath,
+				basedir: project.xcodebuild.getOutputPath().absolutePath,
+				includes: project.xcodebuild.bundleName + ".app.dSYM*/**")
 
 	}
 

--- a/plugin/src/main/groovy/org/openbakery/AbstractDistributeTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/AbstractDistributeTask.groovy
@@ -95,9 +95,12 @@ class AbstractDistributeTask extends AbstractXcodeTask {
 	void createDsymZip(File outputDirectory) {
 
 		def ant = new AntBuilder()
-		ant.zip(destfile: getDsymZipFile(outputDirectory).absolutePath,
-						basedir: project.xcodebuild.getOutputPath().absolutePath,
-						includes: "*dSYM*/**")
+//		ant.zip(destfile: getDsymZipFile(outputDirectory).absolutePath,
+//						basedir: project.xcodebuild.getOutputPath().absolutePath,
+//						includes: "*dSYM*/**")
+        ant.zip(destfile: getDsymZipFile(outputDirectory).absolutePath,
+                basedir: project.xcodebuild.getOutputPath().absolutePath,
+                includes: project.xcodebuild.bundleName + ".app.dSYM*/**")
 
 	}
 


### PR DESCRIPTION
Testflight rejects submissions with more than one dSYM file, so only include the main app one