### PR TITLE
Test class names implemented on Swift running on Xcode 6.1 have a different syntax

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/XcodeTestTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeTestTask.groovy
@@ -76,7 +76,7 @@ class XcodeTestTask extends AbstractXcodeBuildTask {
 
 	def TEST_CASE_PATTERN = ~/^Test Case '(.*)'(.*)/
 
-	def TEST_CLASS_PATTERN = ~/^-\[(\w*)\s(\w*)\]/
+	def TEST_CLASS_PATTERN = ~/^-\[([^\s]*)\s(\w*)\]/
 
 	def TEST_FAILED_PATTERN = ~/.*\*\* TEST FAILED \*\*/
 	def TEST_SUCCEEDED_PATTERN = ~/.*\*\* TEST SUCCEEDED \*\*/

--- a/plugin/src/test/Resource/xcodebuild-output-swift-tests-xcode6_1.txt
+++ b/plugin/src/test/Resource/xcodebuild-output-swift-tests-xcode6_1.txt
@@ -1,0 +1,15 @@
+Test Suite 'All tests' started at 2015-01-20 16:46:22 +0000
+Test Suite 'FooSwiftTestTests.xctest' started at 2015-01-20 16:46:22 +0000
+Test Suite 'FooSwiftTestTests' started at 2015-01-20 16:46:22 +0000
+Test Case '-[FooSwiftTestTests.FooSwiftTestTests testExample]' started.
+Test Case '-[FooSwiftTestTests.FooSwiftTestTests testExample]' passed (0.041 seconds).
+Test Case '-[FooSwiftTestTests.FooSwiftTestTests testPerformanceExample]' started.
+<unknown>:0: Test Case '-[FooSwiftTestTests.FooSwiftTestTests testPerformanceExample]' measured [Time, seconds] average: 0.000, relative standard deviation: 219.011%, values: [0.000018, 0.000001, 0.000001, 0.000001, 0.000001, 0.000001, 0.000001, 0.000001, 0.000001, 0.000001], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "", baselineAverage: , maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
+Test Case '-[FooSwiftTestTests.FooSwiftTestTests testPerformanceExample]' passed (0.254 seconds).
+Test Suite 'FooSwiftTestTests' passed at 2015-01-20 16:46:22 +0000.
+         Executed 2 tests, with 0 failures (0 unexpected) in 0.295 (0.296) seconds
+Test Suite 'FooSwiftTestTests.xctest' passed at 2015-01-20 16:46:22 +0000.
+         Executed 2 tests, with 0 failures (0 unexpected) in 0.295 (0.296) seconds
+Test Suite 'All tests' passed at 2015-01-20 16:46:22 +0000.
+         Executed 2 tests, with 0 failures (0 unexpected) in 0.295 (0.315) seconds
+** TEST SUCCEEDED **

--- a/plugin/src/test/groovy/org/openbakery/XcodeTestTaskTest.groovy
+++ b/plugin/src/test/groovy/org/openbakery/XcodeTestTaskTest.groovy
@@ -157,4 +157,11 @@ class XcodeTestTaskTest {
 
 	}
 
+	@Test
+	void parseSuccessResultForTestsWrittenInSwiftUsingXcode_6_1() {
+		assert xcodeTestTask.parseResult(new File("src/test/Resource/xcodebuild-output-swift-tests-xcode6_1.txt"))
+
+		assert xcodeTestTask.numberSuccess() == 2
+		assert xcodeTestTask.numberErrors() == 0
+	}
 }


### PR DESCRIPTION
I've noticed that XCTests written in Swift on Xcode 6.1 have a different syntax when printing the test class names:

```
Test Case '-[FooSwiftTestTests.FooSwiftTestTests testExample]' started.
```

When running on Xcode 6.0.1 it has a different output:

```
Test Case '-[FooSwiftTestTests testExample]' started.
```

I've changed the test class regex to match anything until a white space character is reached.
