### PR TITLE
Fixing tests on master

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/Destination.groovy
+++ b/plugin/src/main/groovy/org/openbakery/Destination.groovy
@@ -13,6 +13,14 @@ class Destination {
 	String id = null
 	String os = null
 
+	Destination() {
+	}
+
+	Destination(String platform, String name, String os) {
+		this.platform = platform
+		this.name = name
+		this.os = os
+	}
 
 	@Override
 	public java.lang.String toString() {
@@ -31,7 +39,7 @@ class Destination {
 
 		Destination otherDestination = (Destination) other
 
-		if (StringUtils.equals(id, otherDestination.id)) {
+		if (id != null && StringUtils.equals(id, otherDestination.id)) {
 			return true;
 		}
 

--- a/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
@@ -484,14 +484,11 @@ class XcodeBuildPluginExtension {
 
 
 			File xcodeBuildFile = new File(xcode, "Contents/Developer/usr/bin/xcodebuild");
-			if (xcodeBuildFile.exists()) {
+			String xcodeVersion = commandRunner.runWithResult(xcodeBuildFile.absolutePath, "-version");
 
-				String xcodeVersion = commandRunner.runWithResult(xcodeBuildFile.absolutePath, "-version");
-
-				if (xcodeVersion.endsWith(version)) {
-					xcodePath = xcode
-					return
-				}
+			if (xcodeVersion.endsWith(version)) {
+				xcodePath = xcode
+				return
 			}
 		}
 

--- a/plugin/src/test/groovy/org/openbakery/XcodeBuildPluginExtensionTest.groovy
+++ b/plugin/src/test/groovy/org/openbakery/XcodeBuildPluginExtensionTest.groovy
@@ -1,13 +1,13 @@
 package org.openbakery
-
 import org.apache.commons.io.FileUtils
 import org.gmock.GMockController
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.testng.annotations.AfterMethod
-import org.testng.annotations.AfterTest
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
+
+import static java.util.Arrays.asList
 
 /**
  * Created by rene on 24.07.14.
@@ -282,8 +282,7 @@ class XcodeBuildPluginExtensionTest {
 
 
 	@Test
-	void testDeviceListXcode5_mutibleSimualtors() {
-
+	void testDeviceListXcode5_multipleSimulators() {
 		mockXcodePath();
 		mockDisplayName();
 		mockNewerEquivalentDevice(null);
@@ -296,17 +295,8 @@ class XcodeBuildPluginExtensionTest {
 			extension.createXcode5DeviceList()
 		}
 
-		assert extension.destinations.size() == 3 : "expected 1 elements in the availableSimulators list but was: " + extension.destinations.size()
-
-		Destination destination =  extension.destinations[0];
-
-		assert destination.name.equals("iPad");
-		assert destination.platform.equals("iOS Simulator")
-		assert destination.os.equals("7.0")
-
-		assert extension.destinations[1].os.equals("7.1");
-		assert extension.destinations[2].os.equals("6.0");
-
+		assert extension.destinations.size() == 3 : "expected 3 elements in the availableSimulators list but was: " + extension.destinations.size()
+		assert extension.destinations.containsAll(asList(iPadOnSimulatorWith("7.0"), iPadOnSimulatorWith("7.1"), iPadOnSimulatorWith("6.0")))
 	}
 
 
@@ -426,6 +416,10 @@ class XcodeBuildPluginExtensionTest {
 		workspace.mkdirs()
 		assert extension.workspace == "Test.xcworkspace";
 
+	}
+
+	private static Destination iPadOnSimulatorWith(String osVersion) {
+		return new Destination("iOS Simulator", "iPad", osVersion)
 	}
 
 }


### PR DESCRIPTION
I'm getting two test failures on the current master:

```
➜  plugin git:(master) gradle clean test
:clean
:compileJava UP-TO-DATE
:compileGroovy
warning: [options] bootstrap class path not set in conjunction with -source 1.6
1 warning
:processResources
:classes
:compileTestJava UP-TO-DATE
:compileTestGroovy
warning: [options] bootstrap class path not set in conjunction with -source 1.6
1 warning
:processTestResources UP-TO-DATE
:testClasses
:test

Gradle test > org.openbakery.XcodeBuildPluginExtensionTest.testDeviceListXcode5_mutibleSimualtors FAILED
    org.codehaus.groovy.runtime.powerassert.PowerAssertionError at XcodeBuildPluginExtensionTest.groovy:305

Gradle test > org.openbakery.XcodeBuildTaskTest.run_command_xcodeversion FAILED
    java.lang.IllegalStateException at XcodeBuildTaskTest.groovy:360

82 tests completed, 2 failed
:test FAILED
```

The commits in this pull request have some comments explaining the fix, let me know if you have any questions.
