### PR TITLE
Fixing broken test XcodeBuildTaskTest.run_command_xcodeversion.

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
@@ -15,8 +15,6 @@
  */
 package org.openbakery
 
-import org.apache.commons.configuration.plist.XMLPropertyListConfiguration
-import org.apache.commons.io.FilenameUtils
 import org.apache.commons.io.filefilter.SuffixFileFilter
 import org.apache.commons.lang.StringUtils
 import org.gradle.api.Project
@@ -318,29 +316,26 @@ class XcodeBuildPluginExtension {
 
 
 			File xcodeBuildFile = new File(xcode, "Contents/Developer/usr/bin/xcodebuild");
-			if (xcodeBuildFile.exists()) {
+			String xcodeVersion = commandRunner.runWithResult(xcodeBuildFile.absolutePath, "-version");
 
-				String xcodeVersion = commandRunner.runWithResult(xcodeBuildFile.absolutePath, "-version");
+			def VERSION_PATTERN = ~/Xcode\s([^\s]*)\nBuild\sversion\s([^\s]*)/
+			def matcher = VERSION_PATTERN.matcher(xcodeVersion)
+			if (matcher.matches()) {
+				String versionString = matcher[0][1]
+				String buildNumberString = matcher[0][2]
 
-				def VERSION_PATTERN = ~/Xcode\s([^\s]*)\nBuild\sversion\s([^\s]*)/
-				def matcher = VERSION_PATTERN.matcher(xcodeVersion)
-				if (matcher.matches()) {
-					String versionString = matcher[0][1]
-					String buildNumberString = matcher[0][2]
-
-					if (versionString.startsWith(version)) {
-						xcodePath = xcode
-						return
-					}
-
-					if (buildNumberString.equals(version)) {
-						xcodePath = xcode
-						return
-					}
+				if (versionString.startsWith(version)) {
+					xcodePath = xcode
+					return
 				}
 
-
+				if (buildNumberString.equals(version)) {
+					xcodePath = xcode
+					return
+				}
 			}
+
+
 		}
 
 		throw new IllegalStateException("No Xcode found with build number " + version);


### PR DESCRIPTION
It is accessing the filesystem and it will break if you dont have /Applications/Xcode.app in your machine.

"mdfind" will only return paths that exist in the filesystem, so Im just removing the check on our side. If for some reason we still want to check that it exists, then we will need to mock/inject things somehow.

I've also sent a pull request to fix this on master (#126).