### PR TITLE
Capture code sign error output during the xcodebuild compilation step.

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/output/XcodeBuildOutputAppender.groovy
+++ b/plugin/src/main/groovy/org/openbakery/output/XcodeBuildOutputAppender.groovy
@@ -75,7 +75,13 @@ class XcodeBuildOutputAppender implements OutputAppender {
 			if (tokens.length > 1) {
 				currentSourceFile = tokens[1];
 			}
-		} else if (currentSourceFile != null && line.equals("")) {
+		} else if (line.startsWith("Code Sign error:")) {
+			command = "CodeSign"
+			error = true
+			hasOutput = true
+			outputText.append("\n")
+			outputText.append(line)
+		} else if ((currentSourceFile != null || command != null) && line.equals("")) {
 			// end of command
 			if (error) {
 				output.withStyle(StyledTextOutput.Style.Failure).text("   ERROR")
@@ -86,8 +92,10 @@ class XcodeBuildOutputAppender implements OutputAppender {
 			}
 			output.text(" - ");
 			output.text(command)
-			output.text(": ")
-			output.text(currentSourceFile);
+			if (currentSourceFile != null) {
+				output.text(": ")
+				output.text(currentSourceFile);
+			}
 			output.println();
 			if (hasOutput) {
 				output.println(outputText.toString())
@@ -96,7 +104,7 @@ class XcodeBuildOutputAppender implements OutputAppender {
 			reset()
 		} else if (line.endsWith("errors generated.") || line.endsWith("error generated.") || line.startsWith("clang: error:")) {
 			error = true
-		}	else if (line.endsWith("warnings generated.") || line.endsWith("warning generated.")) {
+		} else if (line.endsWith("warnings generated.") || line.endsWith("warning generated.")) {
 			warning = true
 		} else if (!hasOutput && currentSourceFile != null && line.contains(currentSourceFile) && !line.startsWith(" ")) {
 			hasOutput = true

--- a/plugin/src/test/groovy/org/openbakery/output/XcodeBuildOutputAppenderTest.groovy
+++ b/plugin/src/test/groovy/org/openbakery/output/XcodeBuildOutputAppenderTest.groovy
@@ -109,6 +109,12 @@ class XcodeBuildOutputAppenderTest {
 					"\n" +
 					"Ld /Users/dummy/Library/Developer/Xcode/DerivedData/FOO-fbukaldjlcdhljciwtwjdjdwjfqy/Build/Products/Debug-iphonesimulator/UnitTests.octest/UnitTests normal i386"
 
+	def codesignErrorData = "\n" +
+					"Check dependencies\n" +
+					"Code Sign error: No code signing identities found: No valid signing identities (i.e. certificate and private key pair) matching the team ID “Z7L2YBTH45” were found.\n" +
+					"CodeSign error: code signing is required for product type 'App Extension' in SDK 'iOS 8.1'\n" +
+					"\n" +
+					"** BUILD FAILED **"
 
 
 	@Test
@@ -167,6 +173,21 @@ class XcodeBuildOutputAppenderTest {
 		}
 
 		String expected = "   ERROR - Linking: build/DUMMY.build/Release-iphoneos/MyApp.build/Objects-normal/armv7/MyApp\n"
+		assert output.toString().startsWith(expected): "Expected: " + expected + " but was " + output.toString()
+
+	}
+
+	@Test
+	void testCodesignError() {
+		StyledTextOutputStub output = new StyledTextOutputStub()
+
+		XcodeBuildOutputAppender appender = new XcodeBuildOutputAppender(output)
+
+		for (String line in codesignErrorData.split("\n")) {
+			appender.append(line)
+		}
+
+		String expected = "   ERROR - CodeSign\n"
 		assert output.toString().startsWith(expected): "Expected: " + expected + " but was " + output.toString()
 
 	}


### PR DESCRIPTION
Added code to capture error output from the code sign step, if it's run internally by xcodebuild.