### PR TITLE
Example project fails due to naming conflict

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -58,7 +58,7 @@ task release(dependsOn: ':Example:package') {
 	description = 'Performs a build for the device that has the same configuration as the AppStore build, but it is signed using the developer certificate'
 }
 
-task appstore(dependsOn: ':Example:package') {
+task publish(dependsOn: ':Example:package') {
 	description = 'Build for the AppStore'
 }
 
@@ -154,7 +154,7 @@ gradle.taskGraph.whenReady { taskGraph ->
 	
 	// ------------------------------------------------------------------------------------------
 
-	if (taskGraph.hasTask(release) || taskGraph.hasTask(appstore)) {
+	if (taskGraph.hasTask(release) || taskGraph.hasTask(publish)) {
 		println "Configure build settings for release or appstore"
 		xcodebuild {
 			configuration = 'Release'
@@ -166,7 +166,7 @@ gradle.taskGraph.whenReady { taskGraph ->
 	}
 	
 
-	if (taskGraph.hasTask(appstore)) {
+	if (taskGraph.hasTask(publish)) {
 		println "Configure sign settings for the appstore build"
 		xcodebuild {
 			signing {


### PR DESCRIPTION
Having a task and an extension with the same name "appstore" was causing the build to fail. Renaming the example project task solves the problem.

No signature of method: org.gradle.execution.taskgraph.DefaultTaskGraphExecuter.hasTask() is applicable for argument types: (org.openbakery.appstore.AppstorePluginExtension_Decorated) values: [org.openbakery.appstore.AppstorePluginExtension_Decorated@5634a861]
Possible solutions: hasTask(java.lang.String), hasTask(org.gradle.api.Task), addTasks(java.lang.Iterable), isCase(java.lang.Object), asType(java.lang.Class)