### PR TITLE
Fix for null access when publishing to hockeyapp

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/AbstractDistributeTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/AbstractDistributeTask.groovy
@@ -56,7 +56,7 @@ class AbstractDistributeTask extends AbstractXcodeTask {
 		return getDestinationFile(outputDirectory, extension)
 	}
 
-	void copyBundleToDirectory(File outputDirectory, File bundle) {
+	File copyBundleToDirectory(File outputDirectory, File bundle) {
 		if (!outputDirectory.exists()) {
 			outputDirectory.mkdirs()
 		}
@@ -67,15 +67,16 @@ class AbstractDistributeTask extends AbstractXcodeTask {
 		FileUtils.copyFile(getIpaBundle()	, destinationBundle)
 
 		logger.lifecycle("Created bundle archive in {}", outputDirectory)
+
+		return destinationBundle
 	}
 
-	void copyIpaToDirectory(File outputDirectory) {
-		copyBundleToDirectory(outputDirectory, getIpaBundle())
+	File copyIpaToDirectory(File outputDirectory) {
+		return copyBundleToDirectory(outputDirectory, getIpaBundle())
 	}
 
-
-	void copyDsymToDirectory(File outputDirectory) {
-		copyBundleToDirectory(outputDirectory, getDSymBundle())
+	File copyDsymToDirectory(File outputDirectory) {
+		return copyBundleToDirectory(outputDirectory, getDSymBundle())
 	}
 
 	File getIpaBundle() {


### PR DESCRIPTION
Return the destination path when copying IPAs and DSYMs, or there will be a null exception when publishing with hockeyapp. Most calls to copyIpaToDirectory will store the return value in a property, but there was nothing returned, so the next access to said property would fail. Somehow the tests don't seem to capture this.