### PR TITLE
HockeyApp: Fix failed upload of provisioning profile for App Store builds

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/hockeyapp/HockeyAppUploadTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/hockeyapp/HockeyAppUploadTask.groovy
@@ -95,8 +95,11 @@ class HockeyAppUploadTask extends AbstractDistributeTask {
 		logger.debug("repository_url: {} ", project.hockeyapp.repositoryUrl)
 
 		uploadIPAandDSYM(ipaFile, dSYMFile)
-		uploadProvisioningProfile()
-
+		
+		// Uploading the provisioning profiles only works for non-App Store builds
+		if (project.hockeyapp.releaseType != '1') {
+			uploadProvisioningProfile()
+		}
 	}
 
 	def void uploadIPAandDSYM(File ipaFile, File dSYMFile) {


### PR DESCRIPTION
Check if the release type is not 1, that is "store", and only then upload the provisioning profiles.