### PR TITLE
Add CFBundleName as a property

### DIFF
--- a/Documentation/Parameters.md
+++ b/Documentation/Parameters.md
@@ -144,6 +144,9 @@
 
 	default value: empty
 
+* _bundleName_ - If set it override the bundle name in the Info.plist (CFBundleName)
+
+	default value: empty
 
 * _bundleDisplayName_ - If set it override the bundle display name in the Info.plist (CFBundleDisplayName)
 

--- a/plugin/src/main/groovy/org/openbakery/InfoPlistExtension.groovy
+++ b/plugin/src/main/groovy/org/openbakery/InfoPlistExtension.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.Plugin
 class InfoPlistExtension {
 	def String bundleIdentifier = null
 	def String bundleIdentifierSuffix = null
+	def String bundleName = null
 	def String bundleDisplayName = null
 	def String bundleDisplayNameSuffix = null
 	def String version = null

--- a/plugin/src/main/groovy/org/openbakery/InfoPlistModifyTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/InfoPlistModifyTask.groovy
@@ -49,6 +49,11 @@ class InfoPlistModifyTask extends AbstractDistributeTask {
 
 		}
 
+		// Modify bundle bundleName
+		if (project.infoplist.bundleName != null) {
+			plistHelper.setValueForPlist(infoPlist, "CFBundleName", project.infoplist.bundleName)
+		}
+
 		// Modify bundle bundleDisplayName
 		if (project.infoplist.bundleDisplayName != null) {
 			plistHelper.setValueForPlist(infoPlist, "CFBundleDisplayName", project.infoplist.bundleDisplayName)


### PR DESCRIPTION
I tried to create an ipa file using `gradle package` command, then I encountered a problem that the plugin uses CFBundleName as a target app name and `$(PRODUCT_NAME)` is not expanded.
(as you might know, $(PRODUCT_NAME) is the default value of CFBundleName)

so I decided to modify CFBundleName by InfoPlistModify task.

I'd appreciate it if you could review my PR.

