### PR TITLE
Option to prevent failing tests from failing the build

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
@@ -58,6 +58,7 @@ class XcodeBuildPluginExtension {
 	String productName = null
 	String bundleName = null
 	String productType = "app"
+    Boolean testFailureThrowsException = true
 
 	Devices devices = Devices.UNIVERSAL;
 	List<Destination> availableSimulators = []

--- a/plugin/src/main/groovy/org/openbakery/XcodeTestTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeTestTask.groovy
@@ -131,12 +131,16 @@ class XcodeTestTask extends AbstractXcodeBuildTask {
 			TestBuildOutputAppender outputAppender = new TestBuildOutputAppender(output, project)
 			commandRunner.run(project.projectDir.absolutePath, commandList, null, outputAppender)
 		} catch (CommandRunnerException ex) {
-			throw new Exception("Error attempting to run the unit tests!", ex);
+            if(project.xcodebuild.testFailureThrowsException) {
+                throw new Exception("Error attempting to run the unit tests!", ex);
+            }
 		} finally {
 			if (!parseResult(outputFile)) {
 				logger.lifecycle("Tests Failed!")
 				logger.lifecycle(getFailureFromLog(outputFile));
-				throw new Exception("Not all unit tests are successful!")
+                if(project.xcodebuild.testFailureThrowsException) {
+                    throw new Exception("Not all unit tests are successful!")
+                }
 			} 
 			logger.lifecycle("Done")
 		}


### PR DESCRIPTION
I'm currently using Jenkins to run the gradle script, and when a unit test fails, it prevents fails the whole build. This prevents any post build tasks (such as displaying test results) from running. In my case, I'd rather have a post build task decide whether enough tests have failed to fail the build (or mark it as unstable).

I have created a property called 'testFailureThrowsException', which is true by default:

```
xcodebuild {
    testFailureThrowsException = false
}
```

If I'm missing something and there is a better way to do this, please let me know.