### PR TITLE
Add a configurable IPA file name

### DIFF
--- a/Documentation/Parameters.md
+++ b/Documentation/Parameters.md
@@ -23,6 +23,10 @@
 
   default value: empty
 
+* _ipaFileName_ - a custom name for the generated ipa file
+
+  default value: the applicaiton name is used if no ipaFileName is given
+
 ### Sign Settings
 
 * _signing_ - signing configuration that should be used when building for the device

--- a/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
@@ -58,6 +58,7 @@ class XcodeBuildPluginExtension {
 	String productName = null
 	String bundleName = null
 	String productType = "app"
+	String ipaFileName = null
 
 	Devices devices = Devices.UNIVERSAL;
 	List<Destination> availableSimulators = []

--- a/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
@@ -256,6 +256,9 @@ class XcodePlugin implements Plugin<Project> {
 			if (project.hasProperty('xcodebuild.version')) {
 				project.xcodebuild.version = project['xcodebuild.version']
 			}
+			if (project.hasProperty('xcodebuild.ipaFileName')) {
+				project.xcodebuild.ipaFileName = project['xcodebuild.ipaFileName']
+			}
 
 			if (project.hasProperty('hockeykit.displayName')) {
 				project.hockeykit.displayName = project['hockeykit.displayName']

--- a/plugin/src/main/groovy/org/openbakery/packaging/PackageTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/packaging/PackageTask.groovy
@@ -144,7 +144,7 @@ class PackageTask extends AbstractDistributeTask {
 
 
 	private void createZipPackage(File packagePath, String extension) {
-		File packageBundle = new File(outputPath, getApplicationNameFromArchive() + "." + extension)
+		File packageBundle = new File(outputPath, getIpaFileName() + "." + extension)
 		if (!packageBundle.parentFile.exists()) {
 			packageBundle.parentFile.mkdirs()
 		}
@@ -278,5 +278,13 @@ class PackageTask extends AbstractDistributeTask {
 			return bundle.absolutePath + "/"
 		}
 		return bundle.absolutePath + "/Contents/"
+	}
+
+	def getIpaFileName() {
+		if (project.xcodebuild.ipaFileName) {
+			return project.xcodebuild.ipaFileName
+		} else {
+			return getApplicationNameFromArchive()
+		}
 	}
 }


### PR DESCRIPTION
I wanted to have a Jenkins job that generated two separate *.ipa files signed with different provisioning profiles.  To do this, I needed to re-run the package task but have it generate a different file.  So I made the name of the output file customizable.