### PR TITLE
xcode 'TestSuite' matching and affiliated logic is unused when detect…

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/XcodeTestTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeTestTask.groovy
@@ -82,9 +82,6 @@ class XcodeTestTask extends AbstractXcodeBuildTask {
 	def TEST_FAILED_PATTERN = ~/.*\*\* TEST FAILED \*\*/
 	def TEST_SUCCEEDED_PATTERN = ~/.*\*\* TEST SUCCEEDED \*\*/
 
-	def TEST_SUITE_PATTERN = ~/.*Test Suite '(.*)'(.*)/
-
-
 	def DURATION_PATTERN = ~/^\w+\s\((\d+\.\d+).*/
 
 	File outputDirectory = null
@@ -197,8 +194,6 @@ class XcodeTestTask extends AbstractXcodeBuildTask {
 
 		def resultList = []
 
-		List<String> testSuites = null;
-
 		int testRun = 0;
 		boolean endOfDestination = false;
 
@@ -258,25 +253,6 @@ class XcodeTestTask extends AbstractXcodeBuildTask {
 				}
 			}
 
-			def testSuiteMatcher = TEST_SUITE_PATTERN.matcher(line)
-			if (testSuiteMatcher.matches()) {
-
-				String testSuiteName = testSuiteMatcher[0][1].trim();
-				def testSuiteAction = testSuiteMatcher[0][2].trim();
-
-
-				if (testSuiteAction.startsWith('started')) {
-					if (testSuites == null) {
-						testSuites = new ArrayList<String>();
-					}
-					testSuites.add(testSuiteName);
-				} else if (testSuiteAction.startsWith('finished') || testSuiteAction.startsWith('passed') || testSuiteAction.startsWith('failed')) {
-					testSuites.remove(testSuiteName);
-				}
-
-
-			}
-
 			def testSuccessMatcher = TEST_SUCCEEDED_PATTERN.matcher(line)
 			def testFailedMatcher = TEST_FAILED_PATTERN.matcher(line)
 
@@ -301,7 +277,6 @@ class XcodeTestTask extends AbstractXcodeBuildTask {
 				}
 
 				resultList = []
-				testSuites = null
 				endOfDestination = false
 			} else {
 				if (output != null) {

--- a/plugin/src/main/groovy/org/openbakery/XcodeTestTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeTestTask.groovy
@@ -267,7 +267,7 @@ class XcodeTestTask extends AbstractXcodeBuildTask {
 
 
 			if( endOfDestination ) {
-				Destination destination = project.xcodebuild.availableDestinations[testRun]
+				Destination destination = project.xcodebuild.availableDestinations[(testRun - 1)]
 
 				if (this.allResults.containsKey(destination)) {
 					def destinationResultList = this.allResults.get(destination)
@@ -301,18 +301,15 @@ class XcodeTestTask extends AbstractXcodeBuildTask {
 
 	def store() {
 
-
-
 		FileWriter writer = new FileWriter(new File(outputDirectory, "test-results.xml"))
 
 		def xmlBuilder = new MarkupBuilder(writer)
 
 		xmlBuilder.testsuites() {
-			for (Destination destination in project.xcodebuild.availableDestinations) {
-				String name = destination.toPrettyString()
+			for (e in this.allResults) {
+				String name = e.key.toPrettyString()
 
-				def resultList = this.allResults[destination]
-
+				def resultList = e.value
 				int success = 0;
 				int errors = 0;
 				if (resultList != null) {


### PR DESCRIPTION
After using 'endOfDestination' flag, found and removed dead code.

Also adjusted JUnit xml writer to use this.allResults, rather than the available destinations.  This ensures the junit.xml includes all results gathered during the parse. In doing so, I noticed that using the testRun number as an index was incrementing before use and skipping the first destination. XML output is more consistent in my various usages and varying destinations.
