### PR TITLE
OCLint enhancements

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
@@ -517,7 +517,10 @@ class XcodePlugin implements Plugin<Project> {
 	}
 
 	private void configureOCLint(Project project) {
-		project.task(OCLINT_TASK_NAME, type: OCLintTask, group: ANALYTICS_GROUP_NAME)
+		def oclint = project.task(OCLINT_TASK_NAME, type: OCLintTask, group: ANALYTICS_GROUP_NAME)
+		// XCode Build logs should start with a clean build in order for the OCLint to cover all files
+		oclint.dependsOn(project.tasks.getByName('clean'))
+		oclint.dependsOn(project.tasks.getByName(XCODE_BUILD_TASK_NAME))
 	}
 
 

--- a/plugin/src/main/groovy/org/openbakery/oclint/OCLintPluginExtension.groovy
+++ b/plugin/src/main/groovy/org/openbakery/oclint/OCLintPluginExtension.groovy
@@ -8,6 +8,7 @@ import org.gradle.api.Project
 class OCLintPluginExtension {
 
 	def String reportType = "html"
+	def Boolean excludePods = true
 
 	def rules = []
 

--- a/plugin/src/main/groovy/org/openbakery/oclint/OCLintTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/oclint/OCLintTask.groovy
@@ -19,7 +19,7 @@ class OCLintTask extends AbstractXcodeTask {
 
 	def download() {
 		outputDirectory = new File("${project.buildDir.absolutePath}/oclint")
-		downloadDirectory = new File("${project.gradle.gradleHomeDir.absolutePath}/ios")
+		downloadDirectory = new File("${project.gradle.gradleUserHomeDir.absolutePath}/ios")
 		if (!outputDirectory.exists()) {
 			outputDirectory.mkdirs()
 		}


### PR DESCRIPTION
1. Download is not to the volatile build dir 

2. Option to exclude Pods dir from OCLint report. It's unlikely that you can fix Pods bugs in YOUR project. 

3. OCLint depends on clean+xcodebuild. That's the only way to guarantee the compile_commands.json is up to date.

I seem to have broken a bunch of tests. I'll work on that.