### PR TITLE
Fix for codesign developer tools directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes
 * added support for CPD reports. (Thanks to rahulsom) Issue #191
 * added that OCLint rules can be disabled
+* Fixed an issue where codesign would use the wrong version of developer tools
 
 ## 0.11.4 (July 28, 2015)
 

--- a/plugin/src/main/groovy/org/openbakery/CommandRunner.groovy
+++ b/plugin/src/main/groovy/org/openbakery/CommandRunner.groovy
@@ -160,7 +160,9 @@ class CommandRunner {
 		run(Arrays.asList(commandList));
 	}
 
-
+	def run(List<String> commandList, Map<String, String> environment) {
+		run(".", commandList, environment, null)
+	}
 
 	String runWithResult(String... commandList) {
 		return runWithResult(Arrays.asList(commandList));

--- a/plugin/src/main/groovy/org/openbakery/packaging/PackageTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/packaging/PackageTask.groovy
@@ -173,6 +173,8 @@ class PackageTask extends AbstractDistributeTask {
 
 		logger.lifecycle("Codesign {}", bundle)
 
+		def environment = ["DEVELOPER_DIR":project.xcodebuild.xcodePath + "/Contents/Developer/"]
+
 		def codesignCommand = [
 						"/usr/bin/codesign",
 						"--force",
@@ -184,7 +186,7 @@ class PackageTask extends AbstractDistributeTask {
 						"--keychain",
 						project.xcodebuild.signing.keychainPathInternal.absolutePath,
 		]
-		commandRunner.run(codesignCommand)
+		commandRunner.run(codesignCommand, environment)
 
 	}
 


### PR DESCRIPTION
Provide the DEVELOPER_DIR environment variable to the codesign command runner so that it uses the matching version of developer tools