### PR TITLE
Fix an issue where crashlytics also needed DEVELOPER_DIR set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Changes
 * added support for CPD reports. (Thanks to rahulsom) Issue #191
 * added that OCLint rules can be disabled
-* Fixed an issue where codesign would use the wrong version of developer tools
+* Fixed an issue where codesign and crashlytics would use the wrong version of developer tools
 
 ## 0.11.4 (July 28, 2015)
 

--- a/plugin/src/main/groovy/org/openbakery/CommandRunner.groovy
+++ b/plugin/src/main/groovy/org/openbakery/CommandRunner.groovy
@@ -151,7 +151,6 @@ class CommandRunner {
 		run(".", commandList, null, outputAppender)
 	}
 
-
 	def run(List<String> commandList) {
 		run(".", commandList, null, null)
 	}
@@ -162,6 +161,10 @@ class CommandRunner {
 
 	def run(List<String> commandList, Map<String, String> environment) {
 		run(".", commandList, environment, null)
+	}
+
+	def run(List<String> commandList, Map<String, String> environment, OutputAppender outputAppender) {
+		run(".", commandList, environment, outputAppender)
 	}
 
 	String runWithResult(String... commandList) {

--- a/plugin/src/main/groovy/org/openbakery/crashlytics/CrashlyticsUploadTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/crashlytics/CrashlyticsUploadTask.groovy
@@ -78,8 +78,10 @@ class CrashlyticsUploadTask extends AbstractDistributeTask {
 			commandList.push(project.crashlytics.notifications ? 'YES' : 'NO')
 		}
 
+		def environment = ["DEVELOPER_DIR":project.xcodebuild.xcodePath + "/Contents/Developer/"]
+
 		StyledTextOutput output = getServices().get(StyledTextOutputFactory.class).create(CrashlyticsUploadTask.class)
-		commandRunner.run(commandList, new ConsoleOutputAppender(output))
+		commandRunner.run(commandList, environment, new ConsoleOutputAppender(output))
 
 
 	}


### PR DESCRIPTION
Same as the codesign thing; setting DEVELOPER_DIR fixed issues we had where Crashlytics couldn't find the command line tools