### PR TITLE
Fix for wrong entitlements application-identifier in case of InHouse wildcard provisioning profile

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/signing/ProvisioningProfileReader.groovy
+++ b/plugin/src/main/groovy/org/openbakery/signing/ProvisioningProfileReader.groovy
@@ -193,14 +193,14 @@ class ProvisioningProfileReader {
 			def modifiedValues = []
 			currentValue.each { item ->
 				if (item.toString().endsWith('*')) {
-					modifiedValues << item[0..-2] + bundleIdentifier
+					modifiedValues << item.substring(0, currentValue.indexOf('.') + 1) + bundleIdentifier
 				}
 			}
 			plistHelper.setValueForPlist(entitlementFile, value, modifiedValues)
 
 		} else {
 			if (currentValue.toString().endsWith('*')) {
-				plistHelper.setValueForPlist(entitlementFile, value, currentValue[0..-2] + bundleIdentifier)
+				plistHelper.setValueForPlist(entitlementFile, value, currentValue.substring(0, currentValue.indexOf('.') + 1) + bundleIdentifier)
 			}
 		}
 	}


### PR DESCRIPTION
This is a possible fix for #229. We were pushed to deploy our app so this was the quickest way I found. I ran the tests and all passed, however I hadn't have time to check what test case would cover this scenario. 