### PR TITLE
Mystery solved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 ## OS X
 .DS_Store
 
+## created durint test execution
+example/iOS/ExampleWatchkit/userHome/
+
 ## Gradle
 .gradle
 

--- a/plugin/.gitignore
+++ b/plugin/.gitignore
@@ -1,7 +1,6 @@
 *.iml
 *.ipr
 *.iws
-
 build
-
+classes
 .idea

--- a/plugin/src/main/groovy/org/openbakery/signing/AbstractKeychainTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/signing/AbstractKeychainTask.groovy
@@ -13,15 +13,37 @@ import org.openbakery.XcodeBuildPluginExtension
  */
 abstract class AbstractKeychainTask extends AbstractXcodeTask {
 
+    static alreadyResolvedLoginKC_path;
+    public static final String COMMON_SYSTEM_KC_NAME = '/Library/Keychains/login.keychain'
+
+    public static String loginKeychainPath(){
+
+        if (! alreadyResolvedLoginKC_path){
+            String userHome = System.getProperty("user.home")
+            String loginKeychain = userHome + COMMON_SYSTEM_KC_NAME
+            File commonogin_kc = new File(loginKeychain)
+
+            if (! commonogin_kc.exists()){
+                // on my MacOSX, keychain has this bizarre extension. There is no way to rename it.
+                alreadyResolvedLoginKC_path = loginKeychain + '-db'
+            }else{
+                alreadyResolvedLoginKC_path = loginKeychain
+            }
+        }
+
+
+        return alreadyResolvedLoginKC_path
+    }
+
 
 	List<String> getKeychainList() {
 		String keychainList = commandRunner.runWithResult(["security", "list-keychains"])
-
 		List<String> result = []
 
 		for (String keychain in keychainList.split("\n")) {
 			String trimmedKeychain = keychain.replaceAll(/^\s*\"|\"$/, "")
 			if (!trimmedKeychain.equals("/Library/Keychains/System.keychain")) {
+
 				File keychainFile = new File(trimmedKeychain)
 				if (keychainFile.exists()) {
 					result.add(trimmedKeychain);
@@ -48,11 +70,14 @@ abstract class AbstractKeychainTask extends AbstractXcodeTask {
 	 * @return
 	 */
 	def removeGradleKeychainsFromSearchList() {
-		List<String>keychainList = getKeychainList();
-		logger.debug("project.xcodebuild.signing.keychain should not be removed: {}", project.xcodebuild.signing.keychainPathInternal)
-		if (project.xcodebuild.signing.keychainPathInternal != null) {
-			keychainList.remove(project.xcodebuild.signing.keychainPathInternal.absolutePath)
+		List<String> keychainList = getKeychainList();
+        logger.debug('getKeychains returned : {}', keychainList)
+        Signing signing = project.xcodebuild.signing
+
+        if (signing.keychainPathInternal != null) {
+			keychainList.remove(signing.keychainPathInternal.absolutePath)
 		}
+
 		setKeychainList(keychainList)
 	}
 }

--- a/plugin/src/main/groovy/org/openbakery/signing/KeychainCreateTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/signing/KeychainCreateTask.groovy
@@ -17,6 +17,7 @@ package org.openbakery.signing
 
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.InvalidUserDataException
+import org.openbakery.XcodeBuildPluginExtension
 import org.openbakery.xcode.Type
 import org.openbakery.XcodePlugin
 
@@ -24,7 +25,6 @@ class KeychainCreateTask extends AbstractKeychainTask {
 
 
 	KeychainCreateTask() {
-		super()
 		this.description = "Create a keychain that is used for signing the app"
 
 		dependsOn(XcodePlugin.KEYCHAIN_CLEAN_TASK_NAME)
@@ -36,42 +36,42 @@ class KeychainCreateTask extends AbstractKeychainTask {
 
 	@TaskAction
 	def create() {
+		XcodeBuildPluginExtension xcodebuild = project.xcodebuild
 
-
-		if (project.xcodebuild.isSimulatorBuildOf(Type.iOS)) {
+		if (xcodebuild.isSimulatorBuildOf(Type.iOS)) {
 			logger.lifecycle("The simulator build does not need a provisioning profile");
 			return
 		}
 
-		if (project.xcodebuild.signing.keychain) {
-			if (!project.xcodebuild.signing.keychain.exists()) {
-				throw new IllegalStateException("Keychain not found: " + project.xcodebuild.signing.keychain.absolutePath)
+		if (xcodebuild.signing.keychain) {
+			if (!xcodebuild.signing.keychain.exists()) {
+				throw new IllegalStateException("Keychain not found: " + xcodebuild.signing.keychain.absolutePath)
 			}
-			logger.debug("Using keychain {}", project.xcodebuild.signing.keychain)
-			logger.debug("Internal keychain {}", project.xcodebuild.signing.keychainPathInternal)
+			logger.debug("Using keychain {}", xcodebuild.signing.keychain)
+			logger.debug("Internal keychain {}", xcodebuild.signing.keychainPathInternal)
 			return
 		}
 
-		if (project.xcodebuild.signing.certificateURI == null) {
+		if (xcodebuild.signing.certificateURI == null) {
 			logger.debug("not certificateURI specifed so do not create the keychain");
 			return
 		}
 
 
-		if (project.xcodebuild.signing.certificatePassword == null) {
+		if (xcodebuild.signing.certificatePassword == null) {
 			throw new InvalidUserDataException("Property project.xcodebuild.signing.certificatePassword is missing")
 		}
 
-		def certificateFile = download(project.xcodebuild.signing.signingDestinationRoot, project.xcodebuild.signing.certificateURI)
+		def certificateFile = download(xcodebuild.signing.signingDestinationRoot, xcodebuild.signing.certificateURI)
 
-		def keychainPath = project.xcodebuild.signing.keychainPathInternal.absolutePath
+		def keychainPath = xcodebuild.signing.keychainPathInternal.absolutePath
 
 		logger.debug("Create Keychain: {}", keychainPath)
 
 		if (!new File(keychainPath).exists()) {
-			commandRunner.run(["security", "create-keychain", "-p", project.xcodebuild.signing.keychainPassword, keychainPath])
+			commandRunner.run(["security", "create-keychain", "-p", xcodebuild.signing.keychainPassword, keychainPath])
 		}
-		commandRunner.run(["security", "-v", "import", certificateFile, "-k", keychainPath, "-P", project.xcodebuild.signing.certificatePassword, "-T", "/usr/bin/codesign"])
+		commandRunner.run(["security", "-v", "import", certificateFile, "-k", keychainPath, "-P", xcodebuild.signing.certificatePassword, "-T", "/usr/bin/codesign"])
 
 
 		if (getOSVersion().minor >= 9) {
@@ -82,8 +82,8 @@ class KeychainCreateTask extends AbstractKeychainTask {
 		}
 
 		// Set a custom timeout on the keychain if requested
-		if (project.xcodebuild.signing.timeout != null) {
-			commandRunner.run(["security", "-v", "set-keychain-settings", "-lut", project.xcodebuild.signing.timeout.toString(), keychainPath])
+		if (xcodebuild.signing.timeout != null) {
+			commandRunner.run(["security", "-v", "set-keychain-settings", "-lut", xcodebuild.signing.timeout.toString(), keychainPath])
 		}
 	}
 

--- a/plugin/src/test/groovy/org/openbakery/signing/KeychainCleanupTaskSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/signing/KeychainCleanupTaskSpecification.groovy
@@ -43,13 +43,12 @@ class KeychainCleanupTaskSpecification extends Specification {
 
 	def "delete keychain OS X 10.8"() {
 		given:
-		System.setProperty("os.version", "10.8.0");
-		String userHome = System.getProperty("user.home")
-		String loginKeychain = userHome + "/Library/Keychains/login.keychain"
+		System.setProperty("os.version", "10.8.0")
+		String loginKeychain = AbstractKeychainTask.loginKeychainPath()
 
 		String result = "    \""+ loginKeychain + "\"\n" +
 										"    \"/Library/Keychains/" + XcodeBuildPluginExtension.KEYCHAIN_NAME_BASE + "delete-me.keychain\"\n" +
-										"    \"/Library/Keychains/System.keychain\"";
+										"    \"/Library/Keychains/System.keychain\""
 		commandRunner.runWithResult(["security", "list-keychains"]) >> result
 
 		when:
@@ -62,13 +61,13 @@ class KeychainCleanupTaskSpecification extends Specification {
 
 	def "delete keychain OS X 10.9"() {
 		given:
-		System.setProperty("os.version", "10.9.0");
-		String userHome = System.getProperty("user.home")
-		String loginKeychain = userHome + "/Library/Keychains/login.keychain"
+		System.setProperty("os.version", "10.9.0")
 
-		String result = "    \""+ userHome + "/Library/Keychains/login.keychain\"\n" +
+		String loginKeychain = AbstractKeychainTask.loginKeychainPath()
+
+		String result = "    \""+ loginKeychain + "\n" +
 										"    \"/Library/Keychains/" + XcodeBuildPluginExtension.KEYCHAIN_NAME_BASE + "delete-me.keychain\"\n" +
-										"    \"/Library/Keychains/System.keychain\"";
+										"    \"/Library/Keychains/System.keychain\""
 
 		commandRunner.runWithResult(["security", "list-keychains"]) >> result
 
@@ -81,8 +80,7 @@ class KeychainCleanupTaskSpecification extends Specification {
 	}
 
 	String getSecurityList() {
-		String userHome = System.getProperty("user.home")
-		String loginKeychain = userHome + "/Library/Keychains/login.keychain"
+		String loginKeychain = AbstractKeychainTask.loginKeychainPath()
 
 		return  "    \""+ loginKeychain + "\n" +
 						"    \"/Users/me/Go/pipelines/Build-Appstore/build/codesign/gradle-1431356246879.keychain\"\n" +
@@ -95,8 +93,7 @@ class KeychainCleanupTaskSpecification extends Specification {
 
 	def "keychain list update"() {
 		given:
-		String userHome = System.getProperty("user.home")
-		String loginKeychain = userHome + "/Library/Keychains/login.keychain"
+		String loginKeychain = AbstractKeychainTask.loginKeychainPath()
 
 		commandRunner.runWithResult(["security", "list-keychains"]) >> getSecurityList()
 
@@ -117,23 +114,23 @@ class KeychainCleanupTaskSpecification extends Specification {
 		List<String> keychainList = keychainCleanupTask.getKeychainList()
 
 		then:
-		keychainList.size == 1
+		keychainList.size() == 1
 	}
 
 
 	def "remove only missing keychain in list"() {
 		given:
 		System.setProperty("os.version", "10.9.0");
-		String userHome = System.getProperty("user.home")
-		String loginKeychain = userHome + "/Library/Keychains/login.keychain"
+		String loginKeychain = AbstractKeychainTask.loginKeychainPath()
 
 		File keychainFile = new File(project.buildDir, "gradle.keychain");
 		FileUtils.writeStringToFile(keychainFile, "dummy");
 
 		String keychainFileName = keychainFile.absolutePath
+        System.out.println("test gradle kc file is : it " + keychainFileName + " it exits: " + keychainFile.exists())
 
 		String result = "    \"" + loginKeychain + "\n" +
-										"    \"" + keychainFileName + "\n" +
+                                        "    \"" + keychainFileName + "\n" +
 										"    \"/Library/Keychains/System.keychain\"";
 
 		commandRunner.runWithResult(["security", "list-keychains"]) >> result

--- a/plugin/src/test/groovy/org/openbakery/signing/KeychainCreateTaskSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/signing/KeychainCreateTaskSpecification.groovy
@@ -75,8 +75,7 @@ class KeychainCreateTaskSpecification extends Specification {
 
 		project.xcodebuild.signing.keychainPathInternal.createNewFile()
 
-		String userHome = System.getProperty("user.home")
-		String result = "    \""+ userHome + "/Library/Keychains/login.keychain\"";
+		String result = "    \"" + AbstractKeychainTask.loginKeychainPath() + "\"";
 		commandRunner.runWithResult( ["security", "list-keychains"]) >> result
 
 		when:
@@ -84,7 +83,7 @@ class KeychainCreateTaskSpecification extends Specification {
 
 		then:
 		1 * commandRunner.run(["security", "-v", "import",  keychainDestinationFile.toString(), "-k", project.xcodebuild.signing.keychainPathInternal.toString(), "-P", "password", "-T", "/usr/bin/codesign"])
-		1 * commandRunner.run(["security", "list-keychains", "-s", userHome + "/Library/Keychains/login.keychain", project.xcodebuild.signing.keychainPathInternal.toString()])
+		1 * commandRunner.run(["security", "list-keychains", "-s", AbstractKeychainTask.loginKeychainPath(), project.xcodebuild.signing.keychainPathInternal.toString()])
 	}
 
 }

--- a/plugin/src/test/groovy/org/openbakery/signing/KeychainRemoveFromSearchListTaskSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/signing/KeychainRemoveFromSearchListTaskSpecification.groovy
@@ -32,13 +32,25 @@ class KeychainRemoveFromSearchListTaskSpecification extends Specification {
 		task = project.tasks.findByName(XcodePlugin.KEYCHAIN_REMOVE_SEARCH_LIST_TASK_NAME);
 		task.commandRunner = commandRunner
 
-		String userHome = System.getProperty("user.home")
-		loginKeychain = userHome + "/Library/Keychains/login.keychain"
-
+		loginKeychain = AbstractKeychainTask.loginKeychainPath()
 	}
+
 
 	def cleanup() {
 		FileUtils.deleteDirectory(project.buildDir)
+	}
+
+	def "Login keychain extension can be .keychain or .keychain-db"() {
+		given:
+		String userHome = System.getProperty("user.home")
+		String loginKeychain = userHome + AbstractKeychainTask.COMMON_SYSTEM_KC_NAME
+
+		when:
+		true
+
+		then:
+        AbstractKeychainTask.loginKeychainPath() == loginKeychain || AbstractKeychainTask.loginKeychainPath() == (loginKeychain + '-db')
+		task.group == XcodePlugin.XCODE_GROUP_NAME
 	}
 
 	def "check group"() {


### PR DESCRIPTION
My rig runs Sierra (OSX 10.12.1). 

I've noticed my system  is storing (some of) my keychains with **.keychain-db** extension, instead of just **.keychain**. 
I've played a lot with the keychain around last update, I've done things like duplicate keychain, unlock and copy all from one to another. 
I guess that's not a frequent issue, there is no way for me to rename those files with just .keychain extension. OS just can't resist and override my rename.

My fix is to check if there is a "-db" of login keychain, and use it eventually. I think that's a clean and sound solution, of course it can be improved and maybe placed somewhere else. 