### PR TITLE
Append projectFile to projectDir

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/configuration/XcodeConfigTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/configuration/XcodeConfigTask.groovy
@@ -20,7 +20,10 @@ class XcodeConfigTask extends AbstractXcodeTask {
 
 	@TaskAction
 	void configuration() {
-		def projectFile = new File(project.xcodebuild.projectFile, "project.pbxproj")
+		String absolutePath = "${project.projectDir.absolutePath}/${project.xcodebuild.projectFile}"
+		this.project.logger.debug "projectFile: ${project.xcodebuild.projectFile}"
+		this.project.logger.debug "absolutePath: " + absolutePath
+		def projectFile = new File(absolutePath, "project.pbxproj")
 		xcodeProjectFile = new XcodeProjectFile(project, projectFile)
 		xcodeProjectFile.parse()
 		project.xcodebuild.projectSettings = xcodeProjectFile.getProjectSettings()


### PR DESCRIPTION
Fixes build invocation from parent project for multiproject builds.