### PR TITLE
Revert "Append projectFile to projectDir"

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/configuration/XcodeConfigTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/configuration/XcodeConfigTask.groovy
@@ -20,10 +20,7 @@ class XcodeConfigTask extends AbstractXcodeTask {
 
 	@TaskAction
 	void configuration() {
-		String absolutePath = "${project.projectDir.absolutePath}/${project.xcodebuild.projectFile}"
-		this.project.logger.debug "projectFile: ${project.xcodebuild.projectFile}"
-		this.project.logger.debug "absolutePath: " + absolutePath
-		def projectFile = new File(absolutePath, "project.pbxproj")
+		def projectFile = new File(project.xcodebuild.projectFile, "project.pbxproj")
 		xcodeProjectFile = new XcodeProjectFile(project, projectFile)
 		xcodeProjectFile.parse()
 		project.xcodebuild.projectSettings = xcodeProjectFile.getProjectSettings()


### PR DESCRIPTION
Reverts openbakery/gradle-xcodePlugin#334
This does not work, and is also not needed, because if you take a closer look the projectFile is alwaysed used with `projectFile.absolutePath`