### PR TITLE
Fix multiproject build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 ## Gradle
 .gradle
+userHome
 
 ## Build generated
 build/

--- a/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
@@ -451,7 +451,7 @@ class XcodeBuildPluginExtension {
 		if (projectFile instanceof File) {
 			this.projectFile = projectFile
 		}
-		this.projectFile = new File(projectFile)
+		this.projectFile = new File(project.projectDir.absolutePath, projectFile)
 	}
 
 	File getProjectFile() {

--- a/plugin/src/main/groovy/org/openbakery/cocoapods/AbstractCocoapodsTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/cocoapods/AbstractCocoapodsTask.groovy
@@ -50,7 +50,7 @@ class AbstractCocoapodsTask extends AbstractXcodeTask {
 		ArrayList<String> commandList = []
 		commandList.add podCommand
 		commandList.add parameter
-		commandRunner.run commandList, new ConsoleOutputAppender(output)
+		commandRunner.run project.projectDir.absolutePath, commandList, new ConsoleOutputAppender(output)
 	}
 
 

--- a/plugin/src/test/groovy/org/openbakery/XcodeBuildPluginExtensionSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/XcodeBuildPluginExtensionSpecification.groovy
@@ -443,7 +443,7 @@ class XcodeBuildPluginExtensionSpecification extends Specification {
 		File projectDir =  new File("../example/iOS")
 		project = ProjectBuilder.builder().withProjectDir(projectDir).build()
 		extension = new XcodeBuildPluginExtension(project)
-		extension.projectFile = "../example/iOS/Example/Example.xcodeproj"
+		extension.projectFile = "Example/Example.xcodeproj"
 
 		then:
 		extension.projectFile.canonicalFile == new File("../example/iOS/Example/Example.xcodeproj").canonicalFile

--- a/plugin/src/test/groovy/org/openbakery/cocoapods/CocoapodsBootstrapTaskSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/cocoapods/CocoapodsBootstrapTaskSpecification.groovy
@@ -51,7 +51,7 @@ class CocoapodsBootstrapTaskSpecification extends Specification {
 		cocoapodsBootstrapTask.bootstrap()
 
 		then:
-		1 * commandRunner.run(["/usr/local/bin/pod", "setup"], _)
+		1 * commandRunner.run(_, ["/usr/local/bin/pod", "setup"], _)
 
 	}
 

--- a/plugin/src/test/groovy/org/openbakery/cocoapods/CocoapodsInstallTaskSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/cocoapods/CocoapodsInstallTaskSpecification.groovy
@@ -45,7 +45,7 @@ class CocoapodsInstallTaskSpecification extends Specification {
 		cocoapodsTask.install()
 
 		then:
-		1 * commandRunner.run(["/usr/local/bin/pod", "setup"], _)
+		1 * commandRunner.run(_, ["/usr/local/bin/pod", "setup"], _)
 	}
 
 	def "install pods"() {
@@ -57,7 +57,7 @@ class CocoapodsInstallTaskSpecification extends Specification {
 		cocoapodsTask.install()
 
 		then:
-		1 * commandRunner.run(["/tmp/gems/bin/pod", "install"], _)
+		1 * commandRunner.run(_, ["/tmp/gems/bin/pod", "install"], _)
 
 	}
 
@@ -70,7 +70,7 @@ class CocoapodsInstallTaskSpecification extends Specification {
 		cocoapodsTask.install()
 
 		then:
-		1 * commandRunner.run(["/usr/local/bin/pod", "install"], _)
+		1 * commandRunner.run(_, ["/usr/local/bin/pod", "install"], _)
 
 	}
 
@@ -86,7 +86,7 @@ class CocoapodsInstallTaskSpecification extends Specification {
 		cocoapodsTask.install()
 
 		then:
-		0 * commandRunner.run(["/tmp/gems/bin/pod", "install"], _)
+		0 * commandRunner.run(_, ["/tmp/gems/bin/pod", "install"], _)
 	}
 
 
@@ -106,7 +106,7 @@ class CocoapodsInstallTaskSpecification extends Specification {
 		cocoapodsTask.install()
 
 		then:
-		1 * commandRunner.run(["/tmp/gems/bin/pod", "install"], _)
+		1 * commandRunner.run(_, ["/tmp/gems/bin/pod", "install"], _)
 
 	}
 
@@ -128,7 +128,7 @@ class CocoapodsInstallTaskSpecification extends Specification {
 		cocoapodsTask.install()
 
 		then:
-		1 * commandRunner.run(["/tmp/gems/bin/pod", "install"], _)
+		1 * commandRunner.run(_, ["/tmp/gems/bin/pod", "install"], _)
 	}
 
 
@@ -140,7 +140,7 @@ class CocoapodsInstallTaskSpecification extends Specification {
 		cocoapodsTask.install()
 
 		then:
-		1 * commandRunner.run(["/usr/local/bin/pod", "install"], _)
+		1 * commandRunner.run(_, ["/usr/local/bin/pod", "install"], _)
 
 	}
 }

--- a/plugin/src/test/groovy/org/openbakery/cocoapods/CocoapodsUpdateTaskSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/cocoapods/CocoapodsUpdateTaskSpecification.groovy
@@ -42,7 +42,7 @@ class CocoapodsUpdateTaskSpecification extends Specification {
 		cocoapodsTask.update()
 
 		then:
-		1 * commandRunner.run(["/usr/local/bin/pod", "setup"], _)
+		1 * commandRunner.run(_, ["/usr/local/bin/pod", "setup"], _)
 	}
 
 	def "update pods"() {
@@ -53,7 +53,7 @@ class CocoapodsUpdateTaskSpecification extends Specification {
 		cocoapodsTask.update()
 
 		then:
-		1 * commandRunner.run(["/usr/local/bin/pod", "update"], _)
+		1 * commandRunner.run(_, ["/usr/local/bin/pod", "update"], _)
 	}
 
 	def "update pods with user cocoapods"() {
@@ -65,7 +65,7 @@ class CocoapodsUpdateTaskSpecification extends Specification {
 		cocoapodsTask.update()
 
 		then:
-		1 * commandRunner.run(["/tmp/gems/bin/pod", "update"], _)
+		1 * commandRunner.run(_, ["/tmp/gems/bin/pod", "update"], _)
 	}
 
 	def "depends on"() {
@@ -111,7 +111,7 @@ class CocoapodsUpdateTaskSpecification extends Specification {
 		cocoapodsTask.runPod("setup")
 
 		then:
-		1 * commandRunner.run(["/Users/build/.rvm/gems/ruby-2.3.0/bin/pod", "setup"], _)
+		1 * commandRunner.run(_, ["/Users/build/.rvm/gems/ruby-2.3.0/bin/pod", "setup"], _)
 
 	}
 


### PR DESCRIPTION
Fixes running `build` task from parent project for multiproject builds.

See [GradleXcodeSubprojectExample](https://github.com/phatblat/GradleXcodeSubprojectExample) for an example of the issue.

Fixes #343