### PR TITLE
Add support for projectFile in subdirectory

### DIFF
--- a/libxcode/src/main/groovy/org/openbakery/xcode/Xcodebuild.groovy
+++ b/libxcode/src/main/groovy/org/openbakery/xcode/Xcodebuild.groovy
@@ -120,6 +120,11 @@ class Xcodebuild {
 			commandList.add("-scheme");
 			commandList.add(parameters.scheme);
 
+			if (parameters.project != null) {
+				commandList.add("-project")
+				commandList.add(parameters.project)
+			}
+
 			if (parameters.workspace != null) {
 				commandList.add("-workspace")
 				commandList.add(parameters.workspace)
@@ -288,6 +293,9 @@ class Xcodebuild {
 				commandList.add(parameters.scheme)
 				commandList.add("-workspace")
 				commandList.add(parameters.workspace)
+			} else if (parameters.project != null) {
+				commandList.add("-project")
+				commandList.add(parameters.project)
 			}
 
 			return commandRunner.runWithResult(this.projectDirectory.absolutePath, commandList)

--- a/libxcode/src/main/groovy/org/openbakery/xcode/XcodebuildParameters.groovy
+++ b/libxcode/src/main/groovy/org/openbakery/xcode/XcodebuildParameters.groovy
@@ -12,6 +12,7 @@ class XcodebuildParameters {
 	String target
 	Boolean simulator
 	Type type
+	String project
 	String workspace
 	String configuration
 	File dstRoot
@@ -36,6 +37,7 @@ class XcodebuildParameters {
 						", target='" + target + '\'' +
 						", simulator=" + simulator +
 						", type=" + type +
+						", project='" + project + '\'' +
 						", workspace='" + workspace + '\'' +
 						", configuration='" + configuration + '\'' +
 						", dstRoot=" + dstRoot +

--- a/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
@@ -458,7 +458,14 @@ class XcodeBuildPluginExtension {
 		if (this.projectFile != null) {
 			return this.projectFile
 		}
-		return new File(project.projectDir, project.projectDir.list(new SuffixFileFilter(".xcodeproj"))[0])
+
+		// Look for project files in the projectDir
+		String[] projectFiles = project.projectDir.list(new SuffixFileFilter(".xcodeproj"))
+		if (projectFiles.length > 0 ) {
+			return new File(project.projectDir, projectFiles.first())
+		}
+
+		return null
 	}
 
 	// should be remove in the future, so that every task has its own xcode object
@@ -478,7 +485,7 @@ class XcodeBuildPluginExtension {
 		result.target = this.target
 		result.simulator = this.simulator
 		result.type = this.type
-		result.project = getProjectFile().absolutePath
+		result.project = getProjectFile()?.absolutePath
 		result.workspace = getWorkspace()
 		result.configuration = this.configuration
 		result.dstRoot = this.getDstRoot()

--- a/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
@@ -461,7 +461,7 @@ class XcodeBuildPluginExtension {
 
 		// Look for project files in the projectDir
 		String[] projectFiles = project.projectDir.list(new SuffixFileFilter(".xcodeproj"))
-		if (projectFiles.length > 0 ) {
+		if (projectFiles?.length > 0 ) {
 			return new File(project.projectDir, projectFiles.first())
 		}
 

--- a/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
@@ -478,6 +478,7 @@ class XcodeBuildPluginExtension {
 		result.target = this.target
 		result.simulator = this.simulator
 		result.type = this.type
+		result.project = getProjectFile().absolutePath
 		result.workspace = getWorkspace()
 		result.configuration = this.configuration
 		result.dstRoot = this.getDstRoot()


### PR DESCRIPTION
Currently, the build fails with a message like the following if the `*.xcodeproj` file is not in the same directory as the `build.gradle` file:

```
xcodebuild: error: The directory /Users/me/path/to/repo/GradleXcodeIssueDemo does not contain an Xcode project or workspace.
```

This PR adds support for this by adding a `-project` parameter to the `xcodebuild` command using the `projectFile` property.

This change can be validated in the `ben/fixes` branch of [my fork of the example project](https://github.com/phatblat/GradleXcodeIssueDemo)

resolves #287