### PR TITLE
Copy support directory for message extension

### DIFF
--- a/example/iOS/Example/Example.xcodeproj/project.pbxproj
+++ b/example/iOS/Example/Example.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5AC571C41EF81D03002ED5E8 /* Stickers.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5AC571C31EF81D03002ED5E8 /* Stickers.xcassets */; };
+		5AC571C81EF81D03002ED5E8 /* ExampleStickerPack.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 5AC571C11EF81D03002ED5E8 /* ExampleStickerPack.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		A55E38A91B276F4C00EAF0B8 /* InterfaceController.m in Sources */ = {isa = PBXBuildFile; fileRef = A55E38A81B276F4C00EAF0B8 /* InterfaceController.m */; };
 		A55E38AC1B276F4C00EAF0B8 /* NotificationController.m in Sources */ = {isa = PBXBuildFile; fileRef = A55E38AB1B276F4C00EAF0B8 /* NotificationController.m */; };
 		A55E38AE1B276F4C00EAF0B8 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A55E38AD1B276F4C00EAF0B8 /* Images.xcassets */; };
@@ -38,6 +40,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		5AC571C61EF81D03002ED5E8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A7148CC018A397560010B761 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5AC571C01EF81D03002ED5E8;
+			remoteInfo = ExampleStickerPack;
+		};
 		A7304B471D1AD1210075EBF1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A7148CC018A397560010B761 /* Project object */;
@@ -97,6 +106,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
+				5AC571C81EF81D03002ED5E8 /* ExampleStickerPack.appex in Embed App Extensions */,
 				D99F95521A0EBB11007BB79F /* ExampleTodayWidget.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
@@ -106,6 +116,9 @@
 
 /* Begin PBXFileReference section */
 		39EDF9662C7F0A282AC769B9 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		5AC571C11EF81D03002ED5E8 /* ExampleStickerPack.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ExampleStickerPack.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		5AC571C31EF81D03002ED5E8 /* Stickers.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Stickers.xcassets; sourceTree = "<group>"; };
+		5AC571C51EF81D03002ED5E8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A55E38A21B276F4C00EAF0B8 /* Example WatchKit Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Example WatchKit Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A55E38A51B276F4C00EAF0B8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A55E38A61B276F4C00EAF0B8 /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
@@ -191,6 +204,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5AC571C21EF81D03002ED5E8 /* ExampleStickerPack */ = {
+			isa = PBXGroup;
+			children = (
+				5AC571C31EF81D03002ED5E8 /* Stickers.xcassets */,
+				5AC571C51EF81D03002ED5E8 /* Info.plist */,
+			);
+			path = ExampleStickerPack;
+			sourceTree = "<group>";
+		};
 		990F0037E4739FAAEDACDA5A /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -248,6 +270,7 @@
 				D99F95481A0EBB11007BB79F /* ExampleTodayWidget */,
 				A55E38A31B276F4C00EAF0B8 /* Example WatchKit Extension */,
 				A55E38B51B276F4C00EAF0B8 /* Example WatchKit App */,
+				5AC571C21EF81D03002ED5E8 /* ExampleStickerPack */,
 				A7148CCA18A397560010B761 /* Frameworks */,
 				A7148CC918A397560010B761 /* Products */,
 				990F0037E4739FAAEDACDA5A /* Pods */,
@@ -262,6 +285,7 @@
 				D99F95451A0EBB11007BB79F /* ExampleTodayWidget.appex */,
 				A55E38A21B276F4C00EAF0B8 /* Example WatchKit Extension.appex */,
 				A55E38B11B276F4C00EAF0B8 /* Example WatchKit App.app */,
+				5AC571C11EF81D03002ED5E8 /* ExampleStickerPack.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -349,6 +373,21 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		5AC571C01EF81D03002ED5E8 /* ExampleStickerPack */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5AC571CC1EF81D03002ED5E8 /* Build configuration list for PBXNativeTarget "ExampleStickerPack" */;
+			buildPhases = (
+				5AC571BF1EF81D03002ED5E8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ExampleStickerPack;
+			productName = ExampleStickerPack;
+			productReference = 5AC571C11EF81D03002ED5E8 /* ExampleStickerPack.appex */;
+			productType = "com.apple.product-type.app-extension.messages-sticker-pack";
+		};
 		A55E38A11B276F4C00EAF0B8 /* Example WatchKit Extension */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A55E38C51B276F4C00EAF0B8 /* Build configuration list for PBXNativeTarget "Example WatchKit Extension" */;
@@ -398,6 +437,7 @@
 			dependencies = (
 				D99F95511A0EBB11007BB79F /* PBXTargetDependency */,
 				A7304B4B1D1AD1210075EBF1 /* PBXTargetDependency */,
+				5AC571C71EF81D03002ED5E8 /* PBXTargetDependency */,
 			);
 			name = Example;
 			productName = Example;
@@ -451,6 +491,11 @@
 				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = "Rene Pirringer";
 				TargetAttributes = {
+					5AC571C01EF81D03002ED5E8 = {
+						CreatedOnToolsVersion = 8.3.3;
+						DevelopmentTeam = ED5DV56QPQ;
+						ProvisioningStyle = Automatic;
+					};
 					A55E38A11B276F4C00EAF0B8 = {
 						CreatedOnToolsVersion = 6.3.2;
 						DevelopmentTeam = ED5DV56QPQ;
@@ -506,11 +551,20 @@
 				D99F95441A0EBB11007BB79F /* ExampleTodayWidget */,
 				A55E38A11B276F4C00EAF0B8 /* Example WatchKit Extension */,
 				A55E38B01B276F4C00EAF0B8 /* Example WatchKit App */,
+				5AC571C01EF81D03002ED5E8 /* ExampleStickerPack */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		5AC571BF1EF81D03002ED5E8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5AC571C41EF81D03002ED5E8 /* Stickers.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A55E38A01B276F4C00EAF0B8 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -598,6 +652,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		5AC571C71EF81D03002ED5E8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5AC571C01EF81D03002ED5E8 /* ExampleStickerPack */;
+			targetProxy = 5AC571C61EF81D03002ED5E8 /* PBXContainerItemProxy */;
+		};
 		A7304B481D1AD1210075EBF1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = A55E38A11B276F4C00EAF0B8 /* Example WatchKit Extension */;
@@ -664,6 +723,68 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		5AC571C91EF81D03002ED5E8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = ED5DV56QPQ;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = ExampleStickerPack/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.openbakery.gxp.Example.ExampleStickerPack;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		5AC571CA1EF81D03002ED5E8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = ED5DV56QPQ;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = ExampleStickerPack/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.openbakery.gxp.Example.ExampleStickerPack;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		5AC571CB1EF81D03002ED5E8 /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = ED5DV56QPQ;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = ExampleStickerPack/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.openbakery.gxp.Example.ExampleStickerPack;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Test;
+		};
 		A55E38C01B276F4C00EAF0B8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1111,6 +1232,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		5AC571CC1EF81D03002ED5E8 /* Build configuration list for PBXNativeTarget "ExampleStickerPack" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5AC571C91EF81D03002ED5E8 /* Debug */,
+				5AC571CA1EF81D03002ED5E8 /* Release */,
+				5AC571CB1EF81D03002ED5E8 /* Test */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		A55E38C41B276F4C00EAF0B8 /* Build configuration list for PBXNativeTarget "Example WatchKit App" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/example/iOS/Example/ExampleStickerPack/Info.plist
+++ b/example/iOS/Example/ExampleStickerPack/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>ExampleStickerPack</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.message-payload-provider</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>StickerBrowserViewController</string>
+	</dict>
+</dict>
+</plist>

--- a/example/iOS/Example/ExampleStickerPack/Stickers.xcassets/Contents.json
+++ b/example/iOS/Example/ExampleStickerPack/Stickers.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/example/iOS/Example/ExampleStickerPack/Stickers.xcassets/Sticker Pack.stickerpack/Contents.json
+++ b/example/iOS/Example/ExampleStickerPack/Stickers.xcassets/Sticker Pack.stickerpack/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "properties" : {
+    "grid-size" : "regular"
+  }
+}

--- a/example/iOS/Example/ExampleStickerPack/Stickers.xcassets/iMessage App Icon.stickersiconset/Contents.json
+++ b/example/iOS/Example/ExampleStickerPack/Stickers.xcassets/iMessage App Icon.stickersiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "60x45",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x45",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "67x50",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "74x55",
+      "scale" : "2x"
+    },
+    {
+      "size" : "27x20",
+      "idiom" : "universal",
+      "scale" : "2x",
+      "platform" : "ios"
+    },
+    {
+      "size" : "27x20",
+      "idiom" : "universal",
+      "scale" : "3x",
+      "platform" : "ios"
+    },
+    {
+      "size" : "32x24",
+      "idiom" : "universal",
+      "scale" : "2x",
+      "platform" : "ios"
+    },
+    {
+      "size" : "32x24",
+      "idiom" : "universal",
+      "scale" : "3x",
+      "platform" : "ios"
+    },
+    {
+      "size" : "1024x768",
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "platform" : "ios"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/example/iOS/ExampleWatchkit/ExampleWatchKit Sticker Pack/Info.plist
+++ b/example/iOS/ExampleWatchkit/ExampleWatchKit Sticker Pack/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>ExampleWatchKit Sticker Pack</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.message-payload-provider</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>StickerBrowserViewController</string>
+	</dict>
+</dict>
+</plist>

--- a/example/iOS/ExampleWatchkit/ExampleWatchKit Sticker Pack/Stickers.xcassets/Contents.json
+++ b/example/iOS/ExampleWatchkit/ExampleWatchKit Sticker Pack/Stickers.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/example/iOS/ExampleWatchkit/ExampleWatchKit Sticker Pack/Stickers.xcassets/Sticker Pack.stickerpack/Contents.json
+++ b/example/iOS/ExampleWatchkit/ExampleWatchKit Sticker Pack/Stickers.xcassets/Sticker Pack.stickerpack/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "properties" : {
+    "grid-size" : "regular"
+  }
+}

--- a/example/iOS/ExampleWatchkit/ExampleWatchKit Sticker Pack/Stickers.xcassets/iMessage App Icon.stickersiconset/Contents.json
+++ b/example/iOS/ExampleWatchkit/ExampleWatchKit Sticker Pack/Stickers.xcassets/iMessage App Icon.stickersiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "60x45",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x45",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "67x50",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "74x55",
+      "scale" : "2x"
+    },
+    {
+      "size" : "27x20",
+      "idiom" : "universal",
+      "scale" : "2x",
+      "platform" : "ios"
+    },
+    {
+      "size" : "27x20",
+      "idiom" : "universal",
+      "scale" : "3x",
+      "platform" : "ios"
+    },
+    {
+      "size" : "32x24",
+      "idiom" : "universal",
+      "scale" : "2x",
+      "platform" : "ios"
+    },
+    {
+      "size" : "32x24",
+      "idiom" : "universal",
+      "scale" : "3x",
+      "platform" : "ios"
+    },
+    {
+      "size" : "1024x768",
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "platform" : "ios"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/example/iOS/ExampleWatchkit/ExampleWatchKit Today Extension/TodayViewController.swift
+++ b/example/iOS/ExampleWatchkit/ExampleWatchKit Today Extension/TodayViewController.swift
@@ -21,14 +21,14 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         // Dispose of any resources that can be recreated.
     }
     
-    func widgetPerformUpdateWithCompletionHandler(completionHandler: ((NCUpdateResult) -> Void)) {
+    func widgetPerformUpdate(completionHandler: (@escaping (NCUpdateResult) -> Void)) {
         // Perform any setup necessary in order to update the view.
 
         // If an error is encountered, use NCUpdateResult.Failed
         // If there's no update required, use NCUpdateResult.NoData
         // If there's an update, use NCUpdateResult.NewData
 
-        completionHandler(NCUpdateResult.NewData)
+        completionHandler(NCUpdateResult.newData)
     }
     
 }

--- a/example/iOS/ExampleWatchkit/ExampleWatchkit.xcodeproj/project.pbxproj
+++ b/example/iOS/ExampleWatchkit/ExampleWatchkit.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5AC571EC1EF82F35002ED5E8 /* Stickers.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5AC571EB1EF82F35002ED5E8 /* Stickers.xcassets */; };
+		5AC571F01EF82F35002ED5E8 /* ExampleWatchKit Sticker Pack.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 5AC571E91EF82F34002ED5E8 /* ExampleWatchKit Sticker Pack.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		A70B87631BBD18920023C19B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = A70B87621BBD18920023C19B /* main.m */; };
 		A70B87661BBD18920023C19B /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A70B87651BBD18920023C19B /* AppDelegate.m */; };
 		A70B876C1BBD18920023C19B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A70B876A1BBD18920023C19B /* Main.storyboard */; };
@@ -29,6 +31,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		5AC571EE1EF82F35002ED5E8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A70B87561BBD18920023C19B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5AC571E81EF82F34002ED5E8;
+			remoteInfo = "ExampleWatchKit Sticker Pack";
+		};
 		A70B87781BBD18920023C19B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A70B87561BBD18920023C19B /* Project object */;
@@ -89,6 +98,7 @@
 			dstSubfolderSpec = 13;
 			files = (
 				A7CA61EE1D42210B0007BFF9 /* ExampleWatchKit Today Extension.appex in Embed App Extensions */,
+				5AC571F01EF82F35002ED5E8 /* ExampleWatchKit Sticker Pack.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -96,6 +106,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5AC571E91EF82F34002ED5E8 /* ExampleWatchKit Sticker Pack.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "ExampleWatchKit Sticker Pack.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5AC571EB1EF82F35002ED5E8 /* Stickers.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Stickers.xcassets; sourceTree = "<group>"; };
+		5AC571ED1EF82F35002ED5E8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A70B875E1BBD18920023C19B /* ExampleWatchkit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExampleWatchkit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A70B87621BBD18920023C19B /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		A70B87641BBD18920023C19B /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -165,6 +178,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5AC571EA1EF82F35002ED5E8 /* ExampleWatchKit Sticker Pack */ = {
+			isa = PBXGroup;
+			children = (
+				5AC571EB1EF82F35002ED5E8 /* Stickers.xcassets */,
+				5AC571ED1EF82F35002ED5E8 /* Info.plist */,
+			);
+			path = "ExampleWatchKit Sticker Pack";
+			sourceTree = "<group>";
+		};
 		A70B87551BBD18920023C19B = {
 			isa = PBXGroup;
 			children = (
@@ -173,6 +195,7 @@
 				A70B87841BBD18920023C19B /* ExampleWatchkit WatchKit App */,
 				A70B87931BBD18920023C19B /* ExampleWatchkit WatchKit Extension */,
 				A7CA61E51D42210B0007BFF9 /* ExampleWatchKit Today Extension */,
+				5AC571EA1EF82F35002ED5E8 /* ExampleWatchKit Sticker Pack */,
 				A7CA61E21D42210B0007BFF9 /* Frameworks */,
 				A70B875F1BBD18920023C19B /* Products */,
 			);
@@ -186,6 +209,7 @@
 				A70B87801BBD18920023C19B /* ExampleWatchkit WatchKit App.app */,
 				A70B878F1BBD18920023C19B /* ExampleWatchkit WatchKit Extension.appex */,
 				A7CA61E11D42210B0007BFF9 /* ExampleWatchKit Today Extension.appex */,
+				5AC571E91EF82F34002ED5E8 /* ExampleWatchKit Sticker Pack.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -280,6 +304,21 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		5AC571E81EF82F34002ED5E8 /* ExampleWatchKit Sticker Pack */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5AC571F31EF82F35002ED5E8 /* Build configuration list for PBXNativeTarget "ExampleWatchKit Sticker Pack" */;
+			buildPhases = (
+				5AC571E71EF82F34002ED5E8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ExampleWatchKit Sticker Pack";
+			productName = "ExampleWatchKit Sticker Pack";
+			productReference = 5AC571E91EF82F34002ED5E8 /* ExampleWatchKit Sticker Pack.appex */;
+			productType = "com.apple.product-type.app-extension.messages-sticker-pack";
+		};
 		A70B875D1BBD18920023C19B /* ExampleWatchkit */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A70B87AC1BBD18920023C19B /* Build configuration list for PBXNativeTarget "ExampleWatchkit" */;
@@ -295,6 +334,7 @@
 			dependencies = (
 				A70B87831BBD18920023C19B /* PBXTargetDependency */,
 				A7CA61ED1D42210B0007BFF9 /* PBXTargetDependency */,
+				5AC571EF1EF82F35002ED5E8 /* PBXTargetDependency */,
 			);
 			name = ExampleWatchkit;
 			productName = ExampleWatchkit;
@@ -380,10 +420,14 @@
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Rene Pirringer";
 				TargetAttributes = {
+					5AC571E81EF82F34002ED5E8 = {
+						CreatedOnToolsVersion = 8.3.3;
+						ProvisioningStyle = Automatic;
+					};
 					A70B875D1BBD18920023C19B = {
 						CreatedOnToolsVersion = 7.0.1;
 						DevelopmentTeam = ED5DV56QPQ;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0830;
 						SystemCapabilities = {
 							com.apple.Keychain = {
 								enabled = 1;
@@ -413,7 +457,7 @@
 					A7CA61E01D42210B0007BFF9 = {
 						CreatedOnToolsVersion = 7.3.1;
 						DevelopmentTeam = ED5DV56QPQ;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0830;
 					};
 				};
 			};
@@ -435,11 +479,20 @@
 				A70B877F1BBD18920023C19B /* ExampleWatchkit WatchKit App */,
 				A70B878E1BBD18920023C19B /* ExampleWatchkit WatchKit Extension */,
 				A7CA61E01D42210B0007BFF9 /* ExampleWatchKit Today Extension */,
+				5AC571E81EF82F34002ED5E8 /* ExampleWatchKit Sticker Pack */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		5AC571E71EF82F34002ED5E8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5AC571EC1EF82F35002ED5E8 /* Stickers.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A70B875C1BBD18920023C19B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -524,6 +577,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		5AC571EF1EF82F35002ED5E8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5AC571E81EF82F34002ED5E8 /* ExampleWatchKit Sticker Pack */;
+			targetProxy = 5AC571EE1EF82F35002ED5E8 /* PBXContainerItemProxy */;
+		};
 		A70B87791BBD18920023C19B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = A70B875D1BBD18920023C19B /* ExampleWatchkit */;
@@ -582,6 +640,44 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		5AC571F11EF82F35002ED5E8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				INFOPLIST_FILE = "ExampleWatchKit Sticker Pack/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.openbakery.test.Example.ExampleWatchKit-Sticker-Pack";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		5AC571F21EF82F35002ED5E8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				INFOPLIST_FILE = "ExampleWatchKit Sticker Pack/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.openbakery.test.Example.ExampleWatchKit-Sticker-Pack";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 		A70B87A21BBD18920023C19B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -752,7 +848,7 @@
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "ExampleWatchkit/ExampleWatchkit-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -771,7 +867,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "ExampleWatchkit/ExampleWatchkit-Bridging-Header.h";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -815,7 +911,7 @@
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -832,13 +928,22 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		5AC571F31EF82F35002ED5E8 /* Build configuration list for PBXNativeTarget "ExampleWatchKit Sticker Pack" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5AC571F11EF82F35002ED5E8 /* Debug */,
+				5AC571F21EF82F35002ED5E8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		A70B87591BBD18920023C19B /* Build configuration list for PBXProject "ExampleWatchkit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/libtest/src/main/groovy/org/openbakery/test/ApplicationDummy.groovy
+++ b/libtest/src/main/groovy/org/openbakery/test/ApplicationDummy.groovy
@@ -4,6 +4,7 @@ import org.apache.commons.io.FileUtils
 import org.openbakery.CommandRunner
 import org.openbakery.testdouble.PlistHelperStub
 import org.openbakery.util.PlistHelper
+import org.openbakery.xcode.Extension
 
 class ApplicationDummy {
 
@@ -27,7 +28,6 @@ class ApplicationDummy {
 		FileUtils.deleteDirectory(directory)
 	}
 
-
 	File create(boolean adHoc = true) {
 		// create dummy app
 		File appDirectory = applicationBundle
@@ -48,7 +48,6 @@ class ApplicationDummy {
 
 		plistHelperStub.setValueForPlist(infoPlist, "CFBundleIdentifier", bundleIdentifier)
 
-		File mobileprovision = null
 		if (adHoc) {
 			mobileProvisionFile.add(new File("../libtest/src/main/Resource/test.mobileprovision"))
 		} else {
@@ -57,18 +56,22 @@ class ApplicationDummy {
 		return appDirectory
 	}
 
+	void createPlugin(Extension extension = Extension.today) {
+		switch (extension) {
+			case Extension.today:
+				File mobileProvision = new File("src/test/Resource/test1.mobileprovision")
+				createExtension("ExampleTodayWidget", "org.openbakery.test.ExampleWidget", mobileProvision)
+                break
+			case Extension.sticker:
+				File mobileProvision = new File("src/test/Resource/test2.mobileprovision")
+				createExtension("ExampleStickerPack", "org.openbakery.test.ExampleSticker", mobileProvision)
+				File messageExtensionSupportDirectory = new File(directory, "MessagesApplicationExtensionSupport")
+				messageExtensionSupportDirectory.mkdirs()
+				File messageExtensionSupportStub = new File(messageExtensionSupportDirectory, "MessagesApplicationExtensionStub")
+				FileUtils.writeStringToFile(messageExtensionSupportStub, "fixture")
+				break
+		}
 
-	void createPlugin() {
-		String widgetPath = "PlugIns/ExampleTodayWidget.appex"
-		File widgetsDirectory = new File(directory, widgetPath)
-		FileUtils.writeStringToFile(new File(widgetsDirectory, "ExampleTodayWidget"), "dummy");
-
-		File infoPlistWidget = new File(payloadAppDirectory, widgetPath + "/Info.plist");
-		plistHelperStub.setValueForPlist(infoPlistWidget, "CFBundleIdentifier", "org.openbakery.test.ExampleWidget")
-
-
-		File widgetMobileprovision = new File("src/test/Resource/test1.mobileprovision")
-		mobileProvisionFile.add(widgetMobileprovision)
 	}
 
 	void createSwiftLibs() {
@@ -76,7 +79,6 @@ class ApplicationDummy {
 		FileUtils.writeStringToFile(libSwiftCore, "dummy")
 		File libSwiftCoreArchive = new File(directory, "SwiftSupport/libswiftCore.dylib")
 		FileUtils.writeStringToFile(libSwiftCoreArchive, "dummy")
-
 		File libswiftCoreGraphics = new File(applicationBundle, "Frameworks/libswiftCoreGraphics.dylib")
 		FileUtils.writeStringToFile(libswiftCoreGraphics, "dummy")
 	}
@@ -88,5 +90,22 @@ class ApplicationDummy {
 		FileUtils.writeStringToFile(frameworkFile, "dummy")
 	}
 
+	void createBCSymbolMaps() {
+		File bcsymbolmapsDirectory = new File(directory, "BCSymbolMaps")
+		bcsymbolmapsDirectory.mkdirs()
+		FileUtils.writeStringToFile(new File(bcsymbolmapsDirectory, "14C60358-AC0B-35CF-A079-042050D404EE.bcsymbolmap"), "dummy")
+		FileUtils.writeStringToFile(new File(bcsymbolmapsDirectory, "2154C009-2AC2-3241-9E2E-D8B8046B03C8.bcsymbolmap"), "dummy")
+		FileUtils.writeStringToFile(new File(bcsymbolmapsDirectory, "23CFBC47-4B7D-391C-AB95-48408893A14A.bcsymbolmap"), "dummy")
+	}
 
+	private void createExtension(String name, String bundleIdentifier, File mobileProvision) {
+		String widgetPath = "PlugIns/${name}.appex"
+		File widgetsDirectory = new File(applicationBundle, widgetPath)
+		FileUtils.writeStringToFile(new File(widgetsDirectory, name), "dummy");
+
+		File infoPlistWidget = new File(payloadAppDirectory, widgetPath + "/Info.plist");
+		plistHelperStub.setValueForPlist(infoPlistWidget, "CFBundleIdentifier", bundleIdentifier)
+
+		mobileProvisionFile.add(mobileProvision)
+	}
 }

--- a/libxcode/src/main/groovy/org/openbakery/xcode/Extension.groovy
+++ b/libxcode/src/main/groovy/org/openbakery/xcode/Extension.groovy
@@ -1,0 +1,20 @@
+package org.openbakery.xcode
+
+enum Extension {
+    // https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/AppExtensionKeys.html#//apple_ref/doc/uid/TP40014212-SW15
+    watch("com.apple.watchkit"),
+    today("com.apple.widget-extension"),
+    share("com.apple.share-services"),
+    keyboard("com.apple.keyboard-service"),
+    sticker("com.apple.message-payload-provider")
+
+    String identifier
+
+    Extension(String identifier) {
+        this.identifier = identifier
+    }
+
+    static Extension extensionFromIdentifier(String identifier) {
+        return values().find { it.identifier == identifier }
+    }
+}

--- a/libxcode/src/main/groovy/org/openbakery/xcode/Xcodebuild.groovy
+++ b/libxcode/src/main/groovy/org/openbakery/xcode/Xcodebuild.groovy
@@ -285,6 +285,10 @@ class Xcodebuild {
 			return "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain"
 		}
 
+	String getPlatformDirectory() {
+		return getBuildSetting("PLATFORM_DIR")
+	}
+
 		String loadBuildSettings() {
 			def commandList = [xcode.xcodebuild, "clean", "-showBuildSettings"]
 

--- a/plugin/src/main/groovy/org/openbakery/packaging/PackageTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/packaging/PackageTask.groovy
@@ -72,6 +72,10 @@ class PackageTask extends AbstractDistributeTask {
 			copy(bcSymbolsMaps, applicationFolder.parentFile)
 		}
 
+		enumerateExtensionSupportDirectories(getArchiveDirectory()) { File supportDirectory ->
+			copy(supportDirectory, applicationFolder.parentFile)
+		}
+
 		ApplicationBundle applicationBundle = new ApplicationBundle(applicationPath , project.xcodebuild.type, project.xcodebuild.simulator)
 		appBundles = applicationBundle.getBundles()
 
@@ -204,7 +208,22 @@ class PackageTask extends AbstractDistributeTask {
 			filesToZip << bcSymbolMapsPath
 		}
 
+		enumerateExtensionSupportDirectories(packagePath.getParentFile()) { File supportDirectory ->
+			filesToZip << supportDirectory
+		}
+
 		createZip(packageBundle, packagePath.getParentFile(), packagePath, *filesToZip)
+	}
+
+	private void enumerateExtensionSupportDirectories(File parentDirectory, Closure closure) {
+		def directoryNames = ["MessagesApplicationExtensionSupport"]
+
+		for (String name in directoryNames) {
+			File supportDirectory = new File(parentDirectory, name)
+			if (supportDirectory.exists()) {
+				closure(supportDirectory)
+			}
+		}
 	}
 
 	private void createIpa(File payloadPath, boolean addSwiftSupport) {

--- a/plugin/src/test/Resource/test2.mobileprovision
+++ b/plugin/src/test/Resource/test2.mobileprovision
@@ -1,0 +1,42 @@
+// a Dummy Mobile Provistioning File to test the ProvisioningProfileIDReader
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ApplicationIdentifierPrefix</key>
+	<array>
+		<string>AAAAAAAAAAA</string>
+	</array>
+	<key>CreationDate</key>
+	<date>2011-06-16T08:57:51Z</date>
+	<key>DeveloperCertificates</key>
+	<array>
+		<data>
+		</data>
+	</array>
+	<key>Entitlements</key>
+	<dict>
+		<key>application-identifier</key>
+		<string>AAAAAAAAAAA.org.openbakery.test.ExampleSticker</string>
+		<key>get-task-allow</key>
+		<false/>
+		<key>keychain-access-groups</key>
+		<array>
+			<string>AAAAAAAAAAA.*</string>
+		</array>
+	</dict>
+	<key>ExpirationDate</key>
+	<date>2079-07-04T08:57:51Z</date>
+	<key>Name</key>
+	<string>ad hoc</string>
+	<key>ProvisionedDevices</key>
+	<array>
+		<string>1234</string>
+	</array>
+	<key>TimeToLive</key>
+	<integer>24855</integer>
+	<key>UUID</key>
+	<string>XXXXFFFF-AAAA-BBBB-CCCC-DDDDEEEEFFFF</string>
+	<key>Version</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/plugin/src/test/groovy/org/openbakery/XcodeBuildArchiveTaskSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/XcodeBuildArchiveTaskSpecification.groovy
@@ -633,6 +633,16 @@ class XcodeBuildArchiveTaskSpecification extends Specification {
 
 	def "copy message extension support folder"() {
 		given:
+		XcodeFake xcode = createXcode("8")
+		commandRunner.runWithResult(_, ["xcodebuild", "clean", "-showBuildSettings"]) >> "  PLATFORM_DIR = " + xcode.path + "Contents/Developer/Platforms/iPhoneOS.platform\n"
+		Xcodebuild xcodebuild = new Xcodebuild(new File("."), commandRunner, xcode, new XcodebuildParameters(), [])
+		xcodeBuildArchiveTask.xcode = xcodebuild.xcode
+
+		File stubDirectory = new File(xcodebuild.platformDirectory, "Library/Application Support/MessagesApplicationExtensionStub")
+		stubDirectory.mkdirs()
+		File stub = new File(stubDirectory, "MessagesApplicationExtensionStub")
+		FileUtils.writeStringToFile(stub, "fixture")
+
 		setupProject()
 
 		File extensionDirectory = new File(buildOutputDirectory, "Example.app/PlugIns/ExampleWatchKit Sticker Pack.appex")

--- a/plugin/src/test/groovy/org/openbakery/XcodeBuildArchiveTaskSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/XcodeBuildArchiveTaskSpecification.groovy
@@ -630,4 +630,26 @@ class XcodeBuildArchiveTaskSpecification extends Specification {
 		!new File(projectDir, "build/archive/Example.xcarchive/Products/Applications/Example.app/BCSymbolMaps").exists()
 
 	}
+
+	def "copy message extension support folder"() {
+		given:
+		setupProject()
+
+		File extensionDirectory = new File(buildOutputDirectory, "Example.app/PlugIns/ExampleWatchKit Sticker Pack.appex")
+		extensionDirectory.mkdirs()
+		File infoPlist = new File("../example/iOS/ExampleWatchkit/ExampleWatchKit Sticker Pack/Info.plist")
+		File destinationInfoPlist = new File(extensionDirectory, "Info.plist")
+		FileUtils.copyFile(infoPlist, destinationInfoPlist)
+
+		when:
+		xcodeBuildArchiveTask.archive()
+
+		File supportMessagesDirectory = new File(projectDir, "build/archive/Example.xcarchive/MessagesApplicationExtensionSupport")
+        File supportMessagesStub = new File(supportMessagesDirectory, 'MessagesApplicationExtensionStub')
+
+		then:
+		supportMessagesDirectory.exists()
+		supportMessagesDirectory.list().length == 1
+		supportMessagesStub.exists()
+	}
 }

--- a/plugin/src/test/groovy/org/openbakery/XcodeProjectFileSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/XcodeProjectFileSpecification.groovy
@@ -152,7 +152,7 @@ class XcodeProjectFileSpecification extends Specification {
 		def projectSettings = xcodeProjectFile.getProjectSettings()
 
 		then:
-		projectSettings.size() == 5
+		projectSettings.size() == 6
 	}
 
 	def "parse entitlements file name"() {

--- a/plugin/src/test/groovy/org/openbakery/XcodeProjectFile_WatchSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/XcodeProjectFile_WatchSpecification.groovy
@@ -97,7 +97,7 @@ class XcodeProjectFile_WatchSpecification extends Specification {
 		def projectSettings = xcodeProjectFile.getProjectSettings()
 
 		then:
-		projectSettings.size() == 5
+		projectSettings.size() == 6
 	}
 
 	def "target names"() {

--- a/plugin/src/test/groovy/org/openbakery/packaging/PackageTaskSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/packaging/PackageTaskSpecification.groovy
@@ -593,8 +593,13 @@ class PackageTaskSpecification extends Specification {
 	}
 
 	def "copy extension support directories"() {
+	def "copy extension support directory"() {
 		given:
 		mockExampleApp(true, true)
+        File messageExtensionSupportDirectory = new File(archiveDirectory, "MessagesApplicationExtensionSupport")
+		messageExtensionSupportDirectory.mkdirs()
+		File messageExtensionSupportStub = new File(messageExtensionSupportDirectory, "MessagesApplicationExtensionStub")
+		FileUtils.writeStringToFile(messageExtensionSupportStub, "fixture")
 
         when:
 		packageTask.packageApplication()

--- a/plugin/src/test/groovy/org/openbakery/packaging/PackageTaskSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/packaging/PackageTaskSpecification.groovy
@@ -592,4 +592,16 @@ class PackageTaskSpecification extends Specification {
 		!entries.contains("BCSymbolMaps/")
 	}
 
+	def "copy extension support directories"() {
+		given:
+		mockExampleApp(true, true)
+
+        when:
+		packageTask.packageApplication()
+		List<String> entries = ipaEntries()
+
+		then:
+		entries.contains("MessagesApplicationExtensionSupport/MessagesApplicationExtensionStub")
+	}
+
 }


### PR DESCRIPTION
Some app extensions need a copy of a specific support directory inside the archive and package.
This is a starting point which adds support for sticker packs. It should be easier now to apply this to other extensions that have similar requirements like WatchKit (#259).