### PR TITLE
Update keychain partition list

### DIFF
--- a/libxcode/src/main/groovy/org/openbakery/codesign/Security.groovy
+++ b/libxcode/src/main/groovy/org/openbakery/codesign/Security.groovy
@@ -209,6 +209,6 @@ class Security {
 			throw new IllegalArgumentException("Given keychain does not exist")
 		}
 		String identity = getIdentity(keychainFile)
-		commandRunner.run(["security", "set-key-partition-list", "-S", "apple:", "-k", keychainPassword, "-D", identity, "-t", "private", keychainFile.absolutePath])
+		commandRunner.run(["security", "set-key-partition-list", "-S", "apple:,apple-tool:,codesign:", "-k", keychainPassword, "-D", identity, "-t", "private", keychainFile.absolutePath])
 	}
 }

--- a/libxcode/src/test/groovy/org/openbakery/codesign/SecuritySpecification.groovy
+++ b/libxcode/src/test/groovy/org/openbakery/codesign/SecuritySpecification.groovy
@@ -377,7 +377,7 @@ class SecuritySpecification extends Specification {
 		security.setPartitionList(keychain, "keychain password")
 
 		then:
-		1 * commandRunner.run(["security", "set-key-partition-list", "-S", "apple:", "-k", "keychain password", "-D", "1111222233334444555566667777888899990000", "-t", "private", keychain.absolutePath])
+		1 * commandRunner.run(["security", "set-key-partition-list", "-S", "apple:,apple-tool:,codesign:", "-k", "keychain password", "-D", "1111222233334444555566667777888899990000", "-t", "private", keychain.absolutePath])
 	}
 
 	def "certificate does not exist throws exception"() {


### PR DESCRIPTION
We've been having the same issue as #342, #352 and #373 in our Jenkins environment - this mysterious "unknown error -1=ffffffffffffffff" from the `codesign` command.

```
* What went wrong:
Execution failed for task ':package'.
> Command failed to run (exit code 1): '/usr/bin/codesign --force --sign 948DB5BD62837CCE32A8932975B3D3BA6531B0F7 --verbose /Volumes/Data/workspace/MDK_iOS_MDKApp_master-KP2TV3QN7RLYISBMTOZYLRZWIGYGXKYF3DTICK3DKOSG4UG2T6WQ/build/package/Payload/MDK.app/Frameworks/AFNetworking.framework --keychain /Volumes/Data/workspace/MDK_iOS_MDKApp_master-KP2TV3QN7RLYISBMTOZYLRZWIGYGXKYF3DTICK3DKOSG4UG2T6WQ/build/codesign/gradle-1515608242679.keychain'
  Tail of output:
  /Volumes/Data/workspace/MDK_iOS_MDKApp_master-KP2TV3QN7RLYISBMTOZYLRZWIGYGXKYF3DTICK3DKOSG4UG2T6WQ/build/package/Payload/MDK.app/Frameworks/AFNetworking.framework: unknown error -1=ffffffffffffffff

* Try:
Run with --stacktrace option to get the stack trace. Run with --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1m 10s
```

I was able to resolve this by adding `apple-tool:` and `codesign:` to the partition list as per the last comment in [this SO post](https://stackoverflow.com/questions/39868578/security-codesign-in-sierra-keychain-ignores-access-control-settings-and-ui-p#answer-40870033).

The relevant spock test has been updated, but I had 4 failing tests from the `develop` branch before making any changes. ~~I fixed two of them in `CommandRunnerSpecification` where the `cp` command usage output has changed on macOS 10.13:~~

```
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-apvXc] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-apvXc] source_file ... target_directory
```

**Update:** The changes to `CommandRunnerSpecification` have been reverted since the Travis build image being used appears to still be running macOS 10.12. ([test failures](https://travis-ci.org/openbakery/gradle-xcodePlugin/builds/327883495#L1147))

The 2 other failing tests were in `SigningTest.groovy`, which I wasn't able to find.
- `testMultipleIdentity`
- `testSingleIdentity`

Are these last 2 tests auto-generated?
