### PR TITLE
Better messaging when Xcode project can't be found

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
@@ -454,7 +454,13 @@ class XcodeBuildPluginExtension {
 		if (this.projectFile != null) {
 			return this.projectFile
 		}
-		return new File(project.projectDir, project.projectDir.list(new SuffixFileFilter(".xcodeproj"))[0])
+
+		String[] projectFiles = project.projectDir.list(new SuffixFileFilter(".xcodeproj"))
+		if (!projectFiles || projectFiles.length < 1) {
+			throw new FileNotFoundException("No Xcode project files were found in ${project.projectDir}")
+		}
+
+		return new File(project.projectDir, projectFiles.first())
 	}
 
 	// should be remove in the future, so that every task has its own xcode object

--- a/plugin/src/test/groovy/org/openbakery/XcodeBuildPluginExtensionSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/XcodeBuildPluginExtensionSpecification.groovy
@@ -438,6 +438,21 @@ class XcodeBuildPluginExtensionSpecification extends Specification {
 		extension.projectFile.canonicalFile == new File("../example/iOS/Example/Example.xcodeproj").canonicalFile
 	}
 
+
+	def "get missing project file"() {
+		setup:
+		File projectDir =  new File(".")
+		project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+		extension = new XcodeBuildPluginExtension(project)
+
+		when:
+		File missingFile = extension.projectFile
+
+		then:
+		thrown(FileNotFoundException)
+	}
+
+
 	def "set project file"() {
 		when:
 		File projectDir =  new File("../example/iOS")


### PR DESCRIPTION
When applied to a project that doesn't contain an `.xcodeproj` file the current behaviour doesn't offer much help as to why the build failed. 

## Before

> > Task :xcodebuildConfig FAILED
> Caching disabled for task ':xcodebuildConfig': Caching has not been enabled for the task
> Task ':xcodebuildConfig' is not up-to-date because:
>   Task has not declared any outputs.
> 
> :xcodebuildConfig (Thread[Task worker for ':',5,main]) completed. Took 0.001 secs.
> 
> FAILURE: Build failed with an exception.
> 
> * What went wrong:
> Execution failed for task ':xcodebuildConfig'.
> > 0

Only if the `--stacktrace` option is added to the gradle command will the reason for the failure be shown, but in the middle of a couple screens worth of stack trace.

> :xcodebuildConfig FAILED
> ...
> Caused by: java.lang.ArrayIndexOutOfBoundsException: 0
> 	at org.openbakery.XcodeBuildPluginExtension.getProjectFile(XcodeBuildPluginExtension.groovy:457)
> 	at org.openbakery.XcodeBuildPluginExtension_Decorated.getProjectFile(Unknown Source)

## After

> :xcodebuildConfig FAILED
> 
> FAILURE: Build failed with an exception.
> 
> * What went wrong:
> Execution failed for task ':xcodebuildConfig'.
> > java.io.FileNotFoundException: No Xcode project files were found in /Users/phatblat/dev/gradle/test-xcodePlugin
