### PR TITLE
Erik/coverage xcode9

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/XcodeTestTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeTestTask.groovy
@@ -85,6 +85,9 @@ class XcodeTestTask extends AbstractXcodeBuildTask {
 		} finally {
 			testResultParser = new TestResultParser(testLogsDirectory, destinations)
 			testResultParser.parseAndStore(outputDirectory)
+			//Provide coverage with the test result destinations for id use.
+			project.coverage.setTestResultDestinations(testResultParser.testResults.keySet().toList())
+
 			int numberSuccess = testResultParser.numberSuccess()
 			int numberErrors = testResultParser.numberErrors()
 			if (numberErrors == 0) {

--- a/plugin/src/main/groovy/org/openbakery/coverage/CoveragePluginExtension.groovy
+++ b/plugin/src/main/groovy/org/openbakery/coverage/CoveragePluginExtension.groovy
@@ -1,6 +1,7 @@
 package org.openbakery.coverage
 
 import org.gradle.api.Project
+import org.openbakery.xcode.Destination
 
 class CoveragePluginExtension {
 
@@ -8,6 +9,7 @@ class CoveragePluginExtension {
 	def String exclude = null
 	def String include = null
 	def String outputFormat = null
+	def List<Destination> testResultDestinations
 
 	private final Project project
 
@@ -26,6 +28,9 @@ class CoveragePluginExtension {
 		this.outputDirectory = outputDirectory
 	}
 
+	void setTestResultDestinations(List<Destination> destinations){
+		testResultDestinations = destinations
+	}
 
 	String[] getOutputParameter() {
 		if (outputFormat != null) {

--- a/plugin/src/main/groovy/org/openbakery/coverage/CoverageTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/coverage/CoverageTask.groovy
@@ -4,6 +4,7 @@ import org.apache.commons.io.FilenameUtils
 import org.apache.commons.lang.StringUtils
 import org.gradle.api.tasks.TaskAction
 import org.openbakery.AbstractXcodeTask
+import org.openbakery.xcode.Destination
 
 class CoverageTask extends AbstractXcodeTask {
 
@@ -90,10 +91,18 @@ class CoverageTask extends AbstractXcodeTask {
 		if (this.profileData != null) {
 			return this.profileData
 		}
+
 		def possibleDirectories = [
-						"Build/Intermediates/CodeCoverage/" + project.xcodebuild.target + "/Coverage.profdata",
-						"Build/Intermediates/CodeCoverage/Coverage.profdata"
+				"Build/Intermediates/CodeCoverage/" + project.xcodebuild.target + "/Coverage.profdata",
+				"Build/Intermediates/CodeCoverage/Coverage.profdata"
 		]
+
+		for (Destination destination : project.coverage.testResultDestinations) {
+			project.logger.info(destination.toString())
+			possibleDirectories.add("Build/ProfileData/" + destination.id + "/Coverage.profdata")
+		}
+
+		project.logger.info(possibleDirectories.toString())
 
 		for (String directory : possibleDirectories) {
 			this.profileData = new File(project.xcodebuild.derivedDataPath, directory)

--- a/plugin/src/main/groovy/org/openbakery/coverage/CoverageTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/coverage/CoverageTask.groovy
@@ -98,12 +98,9 @@ class CoverageTask extends AbstractXcodeTask {
 		]
 
 		for (Destination destination : project.coverage.testResultDestinations) {
-			project.logger.info(destination.toString())
 			possibleDirectories.add("Build/ProfileData/" + destination.id + "/Coverage.profdata")
 		}
-
-		project.logger.info(possibleDirectories.toString())
-
+        
 		for (String directory : possibleDirectories) {
 			this.profileData = new File(project.xcodebuild.derivedDataPath, directory)
 			if (this.profileData.exists()) {

--- a/plugin/src/test/groovy/org/openbakery/coverage/CoverageTaskSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/coverage/CoverageTaskSpecification.groovy
@@ -6,6 +6,7 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.openbakery.CommandRunner
 import org.openbakery.XcodeProjectFile
 import org.openbakery.testdouble.AntBuilderStub
+import org.openbakery.xcode.Destination
 import spock.lang.Specification
 
 class CoverageTaskSpecification extends Specification {
@@ -116,6 +117,25 @@ class CoverageTaskSpecification extends Specification {
 		coverageTask.report.commandRunner = Mock(org.openbakery.coverage.command.CommandRunner)
 
 		File profData = new File(project.xcodebuild.derivedDataPath, "Build/Intermediates/CodeCoverage/MyApp/Coverage.profdata")
+		FileUtils.writeStringToFile(profData, "Dummy")
+
+		when:
+		coverageTask.coverage()
+
+		then:
+		coverageTask.report.profileData != null
+	}
+
+	def "profile data coverage with identifier"() {
+		given:
+		project.xcodebuild.xcodebuildParameters.type = "iOS"
+		coverageTask.binary = createFile("MyApp")
+		coverageTask.report.commandRunner = Mock(org.openbakery.coverage.command.CommandRunner)
+		Destination destination = new Destination("MyApp")
+		destination.setId("MyAppID")
+		project.coverage.setTestResultDestinations([destination])
+
+		File profData = new File(project.xcodebuild.derivedDataPath, "Build/ProfileData/MyAppID/Coverage.profdata")
 		FileUtils.writeStringToFile(profData, "Dummy")
 
 		when:


### PR DESCRIPTION
Solves: #371 
The path to the coverage output has changed in Xcode 9. 

Xcode now places the profdata file under the destination identifier associated with the specific device id that the tests ran on. 
Without a clean of the derived data there can be multiple profdata files. Therefore getting the destinations from test result will return the correct GUID that the current builds coverage files live under. 