### PR TITLE
Support for transformations on build settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,18 @@ allprojects {
 		testCompile('org.spockframework:spock-core:1.1-groovy-2.4') {
 			exclude module: 'groovy-all'
 		}
+	}
 
+	// Fix warnings when running tests in IDEA. Example:
+	// SLF4J: Class path contains multiple SLF4J bindings.
+	//    SLF4J: Found binding in [jar:file:/Users/ben/.gradle/caches/4.6/generated-gradle-jars/gradle-api-4.6.jar!/org/slf4j/impl/StaticLoggerBinder.class]
+	// SLF4J: Found binding in [jar:file:/Users/ben/.gradle/caches/modules-2/files-2.1/ch.qos.logback/logback-classic/1.1.5/92353eb144695bba80b31f7bec4f36d871f230ac/logback-classic-1.1.5.jar!/org/slf4j/impl/StaticLoggerBinder.class]
+	// SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
+	// SLF4J: Actual binding is of type [org.gradle.internal.logging.slf4j.OutputEventListenerBackedLoggerContext]
+	configurations.all {
+		resolutionStrategy.dependencySubstitution {
+			substitute module('ch.qos.logback:logback-classic') with module('org.slf4j:slf4j-api:1.7.+')
+		}
 	}
 }
 

--- a/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
@@ -319,7 +319,7 @@ class XcodeBuildPluginExtension {
 		}
 		bundleName = getValueFromInfoPlist("CFBundleName")
 
-		bundleName = variableResolver.resolve(bundleName);
+		bundleName = variableResolver.resolve(bundleName)
 
 		if (StringUtils.isEmpty(bundleName)) {
 			bundleName = this.productName

--- a/plugin/src/main/groovy/org/openbakery/util/VariableResolver.groovy
+++ b/plugin/src/main/groovy/org/openbakery/util/VariableResolver.groovy
@@ -14,23 +14,14 @@ class VariableResolver {
 	}
 
 	/**
-	 * Replaces the variables ${...}
+	 * Replaces the variables in the given string with the actual value. e.g. ${PRODUCT_NAME} od $(PRODUCT_NAME) get
+	 * replaced by the real product name.
 	 *
-	 * @param text
-	 * @return
-	 */
-	String resolveCurlyBrackets(String text) {
-		String result = text
-		binding().each() { key, value ->
-			if (value != null) {
-				result = result.replaceAll('\\$\\{' + key + '\\}', value)
-			}
-		}
-		return result
-	}
-
-	/**
-	 * Replaces the variables in the given string with the actual value. e.g. ${PRODUCT_NAME} od $(PRODUCT_NAME) get replaced by the real product name
+	 * Also handles a single build settings variable transformation like $(PRODUCT_NAME:c99extidentifier).
+	 * See http://codeworkshop.net/posts/xcode-build-setting-transformations
+	 *
+	 * Note the specified transformation is not applied since we are just replacing the entire variable expression with
+	 * a value from the extension.
 	 *
 	 * @param text
 	 * @return
@@ -43,21 +34,30 @@ class VariableResolver {
 			// Skip resolution if the text doesn't contain any variables.
 			return text
 		}
+
 		String result = text
 		binding().each() { key, value ->
 			if (value != null) {
-				result = result.replaceAll('\\$\\(' + key + '\\)', value)
+				/*
+				 * RegEx pattern matching any of these:
+				 * $(VARIABLE) ${VARIABLE} $(VARIABLE:c99extidentifier)
+				 */
+				String regex = "\\\$(\\(|\\{)$key(:\\w+)?(\\)|\\})"
+				if (!result.matches(regex)) {
+					logger.debug("$result NOT found in $text using regex: $regex")
+				}
+				result = result.replaceAll(regex, value)
 			}
 		}
-		return resolveCurlyBrackets(result)
-	}
 
+		return result
+	}
 
 	def binding() {
 		return [
-						"PRODUCT_NAME": project.xcodebuild.productName,
-						"SRC_ROOT"    : project.projectDir.absolutePath,
-						"TARGET_NAME" : project.xcodebuild.target
+			"PRODUCT_NAME": project.xcodebuild.productName,
+			"SRC_ROOT"    : project.projectDir.absolutePath,
+			"TARGET_NAME" : project.xcodebuild.target
 		]
 	}
 }

--- a/plugin/src/main/groovy/org/openbakery/util/VariableResolver.groovy
+++ b/plugin/src/main/groovy/org/openbakery/util/VariableResolver.groovy
@@ -39,6 +39,10 @@ class VariableResolver {
 		if (text == null) {
 			return null
 		}
+		if (!text.contains("\$")) {
+			// Skip resolution if the text doesn't contain any variables.
+			return text
+		}
 		String result = text
 		binding().each() { key, value ->
 			if (value != null) {
@@ -54,6 +58,6 @@ class VariableResolver {
 						"PRODUCT_NAME": project.xcodebuild.productName,
 						"SRC_ROOT"    : project.projectDir.absolutePath,
 						"TARGET_NAME" : project.xcodebuild.target
-		];
+		]
 	}
 }

--- a/plugin/src/test/groovy/org/openbakery/VariableResolverTest.groovy
+++ b/plugin/src/test/groovy/org/openbakery/VariableResolverTest.groovy
@@ -8,20 +8,18 @@ import org.openbakery.util.VariableResolver
 
 class VariableResolverTest {
 
-	VariableResolver resolver;
-	Project project;
+	VariableResolver resolver
+	Project project
 
 	@Before
 	void setUp() {
-
 		File projectDir = new File(System.getProperty("java.io.tmpdir"), "gradle-xcodebuild")
 
 		project = ProjectBuilder.builder().withProjectDir(projectDir).build()
 		project.buildDir = new File(projectDir, 'build').absoluteFile
-		project.apply plugin: org.openbakery.XcodePlugin
+		project.apply plugin: XcodePlugin
 
-
-		resolver = new VariableResolver(project);
+		resolver = new VariableResolver(project)
 	}
 
 	@Test
@@ -44,19 +42,15 @@ class VariableResolverTest {
 
 	@Test
 	void testComplexCurlyBrackets() {
-
 		project.xcodebuild.productName = 'Example'
 		assert 'This$IsAComplexExample'.equals(resolver.resolve('This$IsAComplex${PRODUCT_NAME}'))
-
 
 		project.xcodebuild.productName = 'Example'
 		assert 'The Example is complex'.equals(resolver.resolve('The ${PRODUCT_NAME} is complex'))
 	}
 
-
 	@Test
 	void testComplex() {
-
 		project.xcodebuild.productName = 'Example'
 		assert 'This$IsAComplexExample'.equals(resolver.resolve('This$IsAComplex$(PRODUCT_NAME)'))
 
@@ -65,24 +59,26 @@ class VariableResolverTest {
 		assert 'The Example is complex'.equals(resolver.resolve('The $(PRODUCT_NAME) is complex'))
 	}
 
-
 	@Test
 	void testBoth() {
 		project.xcodebuild.productName = 'Example'
 		assert "Example Example".equals(resolver.resolve('${PRODUCT_NAME} $(PRODUCT_NAME)'))
 	}
 
-
 	@Test
 	void testTargetName() {
 		project.xcodebuild.target = 'MyTarget'
 		assert "MyTarget".equals(resolver.resolve('$(TARGET_NAME)'))
+	}
 
+	@Test
+	void testTargetNameWithTransformation() {
+		project.xcodebuild.target = 'MyTarget'
+		assert "MyTarget".equals(resolver.resolve('$(TARGET_NAME:c99extidentifier)'))
 	}
 
 	@Test
 	void testUnknownVariable() {
 		assert '$(FOOBAR)'.equals(resolver.resolve('$(FOOBAR)'))
 	}
-
 }


### PR DESCRIPTION
Sometimes Xcode build settings contain [transformations](http://codeworkshop.net/posts/xcode-build-setting-transformations) which operate on the build setting value, modifying it like simple [shell parameter expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html).

When one of these transformations is present, it breaks the logic in [VariableResolver](https://github.com/openbakery/gradle-xcodePlugin/blob/860edafdc63bc4fc9a7058b73501fc8835c6ec7e/plugin/src/main/groovy/org/openbakery/util/VariableResolver.groovy). This PR adds support for these transformations.

- `$(TARGET_NAME:c99extidentifier)`

Currently this only supports a single transformation (I've never seen them chained in a real project), but the regex could easily be changed to support chained transformations.

Fixes #361