### PR TITLE
feature/MASSDE-181 : Bootstrap task

### DIFF
--- a/libxcode/src/main/groovy/org/openbakery/CommandRunner.groovy
+++ b/libxcode/src/main/groovy/org/openbakery/CommandRunner.groovy
@@ -76,7 +76,8 @@ class CommandRunner {
 			commandOutputBuffer = new CircularFifoBuffer(20);
 		}
 
-		def commandsAsStrings = commandList.collect { it.toString() } // GStrings don't play well with ProcessBuilder
+		def commandsAsStrings = commandList.collect { it.toString() }
+		// GStrings don't play well with ProcessBuilder
 		def processBuilder = new ProcessBuilder(commandsAsStrings)
 		processBuilder.redirectErrorStream(true)
 		processBuilder.directory(new File(directory))
@@ -172,20 +173,35 @@ class CommandRunner {
 	}
 
 	String runWithResult(String... commandList) {
-		return runWithResult(Arrays.asList(commandList));
+		return runWithResult(Arrays.asList(commandList))
+	}
+
+	String runWithResult(Map<String, String> environmentValues,
+						 String... commandList) {
+		return runWithResult(defaultBaseDirectory,
+				commandList.toList(),
+				environmentValues,
+				null)
 	}
 
 	String runWithResult(List<String> commandList) {
 		return runWithResult(defaultBaseDirectory, commandList)
 	}
 
-	String runWithResult(String directory, List<String> commandList) {
-		return runWithResult(directory, commandList, null, null)
+	String runWithResult(String directory,
+						 List<String> commandList) {
+		return runWithResult(directory,
+				commandList,
+				null,
+				null)
 	}
 
-	String runWithResult(String directory, List<String> commandList, Map<String, String> environment, OutputAppender outputAppender) {
+	String runWithResult(String directory,
+						 List<String> commandList,
+						 Map<String, String> environment,
+						 OutputAppender outputAppender) {
 		commandOutputBuffer = new ArrayList<>();
-		run(directory, commandList, environment, outputAppender);
+		run(directory, commandList, environment, outputAppender)
 		String result = commandOutputBuffer.join("\n")
 		commandOutputBuffer = null;
 		return result

--- a/libxcode/src/main/groovy/org/openbakery/CommandRunner.groovy
+++ b/libxcode/src/main/groovy/org/openbakery/CommandRunner.groovy
@@ -76,8 +76,7 @@ class CommandRunner {
 			commandOutputBuffer = new CircularFifoBuffer(20);
 		}
 
-		def commandsAsStrings = commandList.collect { it.toString() }
-		// GStrings don't play well with ProcessBuilder
+		def commandsAsStrings = commandList.collect { it.toString() } // GStrings don't play well with ProcessBuilder
 		def processBuilder = new ProcessBuilder(commandsAsStrings)
 		processBuilder.redirectErrorStream(true)
 		processBuilder.directory(new File(directory))

--- a/libxcode/src/main/groovy/org/openbakery/xcode/Version.groovy
+++ b/libxcode/src/main/groovy/org/openbakery/xcode/Version.groovy
@@ -30,8 +30,6 @@ class Version implements Comparable<Version> {
 		} catch (InputMismatchException ex) {
 			suffix = versionScanner.next()
 		}
-
-
 	}
 
 	@Override

--- a/libxcode/src/main/groovy/org/openbakery/xcode/Xcode.groovy
+++ b/libxcode/src/main/groovy/org/openbakery/xcode/Xcode.groovy
@@ -18,7 +18,8 @@ class Xcode {
 	public static final String XCODE_CONTENT_DEVELOPER = "Contents/Developer"
 	public static final String ENV_DEVELOPER_DIR = "DEVELOPER_DIR"
 	public static final String XCODE_CONTENT_XC_RUN = "/$XCODE_CONTENT_DEVELOPER/usr/bin/xcrun"
-	public static final String XCODE_CONTENT_XCODE_BUILD = "$XCODE_CONTENT_DEVELOPER/usr/bin/xcodebuild"
+	public static
+	final String XCODE_CONTENT_XCODE_BUILD = "$XCODE_CONTENT_DEVELOPER/usr/bin/xcodebuild"
 
 	private final Logger logger = LoggerFactory.getLogger(Xcode.class)
 
@@ -45,9 +46,11 @@ class Xcode {
 	 */
 	Map<String, String> getXcodeSelectEnvValue(String version) {
 		setVersionFromString(version)
-
+		File file = new File(xcodePath, XCODE_CONTENT_DEVELOPER)
 		HashMap<String, String> result = new HashMap<String, String>()
-		result.put(ENV_DEVELOPER_DIR, new File(xcodePath, XCODE_CONTENT_DEVELOPER).absolutePath)
+		if (file.exists()) {
+			result.put(ENV_DEVELOPER_DIR, file.absolutePath)
+		}
 		return result
 	}
 

--- a/libxcode/src/main/groovy/org/openbakery/xcode/Xcode.groovy
+++ b/libxcode/src/main/groovy/org/openbakery/xcode/Xcode.groovy
@@ -1,6 +1,7 @@
 package org.openbakery.xcode
 
 import groovy.transform.CompileStatic
+import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesting
 import org.openbakery.CommandRunner
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -10,147 +11,153 @@ import java.util.regex.Pattern
 
 @CompileStatic
 class Xcode {
-	private Version version = null
-	private String xcodePath
+    private Version version = null
+    private String xcodePath
 
-	private final CommandRunner commandRunner
+    @VisibleForTesting
+    private CommandRunner commandRunner
 
-	public static final String XCODE_CONTENT_DEVELOPER = "Contents/Developer"
-	public static final String ENV_DEVELOPER_DIR = "DEVELOPER_DIR"
-	public static final String XCODE_CONTENT_XC_RUN = "/$XCODE_CONTENT_DEVELOPER/usr/bin/xcrun"
-	public static
-	final String XCODE_CONTENT_XCODE_BUILD = "$XCODE_CONTENT_DEVELOPER/usr/bin/xcodebuild"
+    public static final String ENV_DEVELOPER_DIR = "DEVELOPER_DIR"
+    public static final String XCODE_ACTION_XC_SELECT = "xcode-select"
+    public static final String XCODE_CONTENT_DEVELOPER = "Contents/Developer"
+    public static final String XCODE_CONTENT_XC_RUN = "/$XCODE_CONTENT_DEVELOPER/usr/bin/xcrun"
+    public static final String XCODE_CONTENT_XCODE_BUILD = "$XCODE_CONTENT_DEVELOPER/usr/bin/xcodebuild"
 
-	private final Logger logger = LoggerFactory.getLogger(Xcode.class)
+    private final Logger logger = LoggerFactory.getLogger(Xcode.class)
 
-	private static final Pattern VERSION_PATTERN = ~/Xcode\s([^\s]*)\nBuild\sversion\s([^\s]*)/
+    private static final Pattern VERSION_PATTERN = ~/Xcode\s([^\s]*)\nBuild\sversion\s([^\s]*)/
 
-	Xcode(CommandRunner commandRunner) {
-		this(commandRunner, null)
-	}
+    Xcode(CommandRunner commandRunner) {
+        this(commandRunner, null)
+    }
 
-	Xcode(CommandRunner commandRunner, String version) {
-		logger.debug("create xcode with version {}", version)
-		this.commandRunner = commandRunner
-		if (version != null) {
-			setVersionFromString(version)
-		}
-	}
+    Xcode(CommandRunner commandRunner, String version) {
+        logger.debug("create xcode with version {}", version)
+        this.commandRunner = commandRunner
+        if (version != null) {
+            setVersionFromString(version)
+        }
+    }
 
-	/**
-	 * Provide the environments values to provide to the command line runner to select
-	 * a Xcode version without using `xcode-select -s` who requires `sudo`.
-	 *
-	 * @param version : The required Xcode version
-	 * @return A map of environment variables to pass to the command runner
-	 */
-	Map<String, String> getXcodeSelectEnvValue(String version) {
-		setVersionFromString(version)
-		File file = new File(xcodePath, XCODE_CONTENT_DEVELOPER)
-		HashMap<String, String> result = new HashMap<String, String>()
-		if (file.exists()) {
-			result.put(ENV_DEVELOPER_DIR, file.absolutePath)
-		}
-		return result
-	}
+    CommandRunner getCommandRunner() {
+        return commandRunner
+    }
 
-	void setVersionFromString(String version) throws IllegalArgumentException {
-		if (version == null) {
-			throw new IllegalArgumentException()
-		}
+    /**
+     * Provide the environments values to provide to the command line runner to select
+     * a Xcode version without using `xcode-select -s` who requires `sudo`.
+     *
+     * @param version : The required Xcode version
+     * @return A map of environment variables to pass to the command runner
+     */
+    Map<String, String> getXcodeSelectEnvValue(String version) {
+        setVersionFromString(version)
+        File file = new File(xcodePath, XCODE_CONTENT_DEVELOPER)
+        HashMap<String, String> result = new HashMap<String, String>()
+        if (file.exists()) {
+            result.put(ENV_DEVELOPER_DIR, file.absolutePath)
+        }
+        return result
+    }
 
-		final Version requiredVersion = new Version(version)
+    void setVersionFromString(String version) throws IllegalArgumentException {
+        if (version == null) {
+            throw new IllegalArgumentException()
+        }
 
-		Optional<File> result = Optional.ofNullable(resolveInstalledXcodeVersionsList()
-				.split("\n")
-				.iterator()
-				.collect { new File(it as File, XCODE_CONTENT_XCODE_BUILD) }
-				.findAll { it.exists() }
-				.find {
-					Version candidate = getXcodeVersion(it.absolutePath)
+        final Version requiredVersion = new Version(version)
 
-					boolean versionStartWith = candidate.toString()
-							.startsWith(requiredVersion.toString())
+        Optional<File> result = Optional.ofNullable(resolveInstalledXcodeVersionsList()
+                .split("\n")
+                .iterator()
+                .collect { new File(it as File, XCODE_CONTENT_XCODE_BUILD) }
+                .findAll { it.exists() }
+                .find {
+            Version candidate = getXcodeVersion(it.absolutePath)
 
-					boolean versionHasSuffix = (candidate.suffix != null
-							&& requiredVersion.suffix != null
-							&& candidate.suffix.equalsIgnoreCase(requiredVersion.suffix))
+            boolean versionStartWith = candidate.toString()
+                    .startsWith(requiredVersion.toString())
 
-					return versionHasSuffix || versionStartWith
-				})
+            boolean versionHasSuffix = (candidate.suffix != null
+                    && requiredVersion.suffix != null
+                    && candidate.suffix.equalsIgnoreCase(requiredVersion.suffix))
 
-		if (result.isPresent()) {
-			selectXcode(result.get())
-		} else {
-			throw new IllegalStateException("No Xcode found with build number " + version)
-		}
-	}
+            return versionHasSuffix || versionStartWith
+        })
 
-	void selectXcode(File file) {
-		String absolutePath = file.absolutePath
-		Version xcodeVersion = getXcodeVersion(absolutePath)
-		xcodePath = new File(absolutePath - XCODE_CONTENT_XCODE_BUILD)
-		this.version = xcodeVersion
-	}
+        if (result.isPresent()) {
+            selectXcode(result.get())
+        } else {
+            throw new IllegalStateException("No Xcode found with build number " + version)
+        }
+    }
 
-	String resolveInstalledXcodeVersionsList() {
-		return commandRunner.runWithResult("mdfind",
-				"kMDItemCFBundleIdentifier=com.apple.dt.Xcode")
-	}
+    void selectXcode(File file) {
+        String absolutePath = file.absolutePath
+        Version xcodeVersion = getXcodeVersion(absolutePath)
+        xcodePath = new File(absolutePath - XCODE_CONTENT_XCODE_BUILD)
+        this.version = xcodeVersion
+    }
 
-	Version getXcodeVersion(String xcodeBuildCommand) {
-		String xcodeVersion = commandRunner.runWithResult(xcodeBuildCommand,
-				"-version")
+    String resolveInstalledXcodeVersionsList() {
+        return commandRunner.runWithResult("mdfind",
+                "kMDItemCFBundleIdentifier=com.apple.dt.Xcode")
+    }
 
-		Matcher matcher = VERSION_PATTERN.matcher(xcodeVersion)
-		if (matcher.matches()) {
-			Version version = new Version(matcher.group(1))
-			version.suffix = matcher.group(2)
-			return version
-		}
-		return null
-	}
+    Version getXcodeVersion(String xcodeBuildCommand) {
+        String xcodeVersion = commandRunner.runWithResult(xcodeBuildCommand,
+                "-version")
 
-	Version getVersion() {
-		if (this.version == null) {
-			this.version = getXcodeVersion(getXcodebuild())
-		}
-		return this.version
-	}
+        Matcher matcher = VERSION_PATTERN.matcher(xcodeVersion)
+        if (matcher.matches()) {
+            Version version = new Version(matcher.group(1))
+            version.suffix = matcher.group(2)
+            return version
+        }
+        return null
+    }
 
-	String getPath() {
-		if (xcodePath == null) {
-			String result = commandRunner.runWithResult("xcode-select", "-p")
-			xcodePath = result - "/$XCODE_CONTENT_DEVELOPER"
-		}
-		return xcodePath
-	}
+    Version getVersion() {
+        if (this.version == null) {
+            this.version = getXcodeVersion(getXcodebuild())
+        }
+        return this.version
+    }
 
-	String getXcodebuild() {
-		if (xcodePath != null) {
-			return new File(xcodePath, XCODE_CONTENT_XCODE_BUILD).absolutePath
-		}
-		return "xcodebuild"
-	}
+    String getPath() {
+        if (xcodePath == null) {
+            String result = commandRunner.runWithResult(XCODE_ACTION_XC_SELECT
+                    , "-p")
+            xcodePath = result - "/$XCODE_CONTENT_DEVELOPER"
+        }
+        return xcodePath
+    }
 
-	String getAltool() {
-		return getPath() + "/Contents/Applications/Application Loader" +
-				".app/Contents/Frameworks/ITunesSoftwareService.framework/Support/altool"
-	}
+    String getXcodebuild() {
+        if (xcodePath != null) {
+            return new File(xcodePath, XCODE_CONTENT_XCODE_BUILD).absolutePath
+        }
+        return "xcodebuild"
+    }
 
-	String getXcrun() {
-		return getPath() + XCODE_CONTENT_XC_RUN
-	}
+    String getAltool() {
+        return getPath() + "/Contents/Applications/Application Loader" +
+                ".app/Contents/Frameworks/ITunesSoftwareService.framework/Support/altool"
+    }
 
-	String getSimctl() {
-		return getPath() + "/$XCODE_CONTENT_DEVELOPER/usr/bin/simctl"
-	}
+    String getXcrun() {
+        return getPath() + XCODE_CONTENT_XC_RUN
+    }
 
-	@Override
-	String toString() {
-		return "Xcode{" +
-				"xcodePath='" + xcodePath + '\'' +
-				", version=" + version +
-				'}'
-	}
+    String getSimctl() {
+        return getPath() + "/$XCODE_CONTENT_DEVELOPER/usr/bin/simctl"
+    }
+
+    @Override
+    String toString() {
+        return "Xcode{" +
+                "xcodePath='" + xcodePath + '\'' +
+                ", version=" + version +
+                '}'
+    }
 }

--- a/libxcode/src/test/groovy/org/openbakery/xcode/XcodeSpecification.groovy
+++ b/libxcode/src/test/groovy/org/openbakery/xcode/XcodeSpecification.groovy
@@ -2,224 +2,249 @@ package org.openbakery.xcode
 
 import org.apache.commons.io.FileUtils
 import org.openbakery.CommandRunner
-import org.openbakery.xcode.Version
-import org.openbakery.xcode.Xcode
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class XcodeSpecification extends Specification {
 
-	Xcode xcode
+    Xcode xcode
 
-	CommandRunner commandRunner = Mock(CommandRunner)
+    CommandRunner commandRunner = Mock(CommandRunner)
 
-	File xcode7_1_1
-	File xcode6_1
-	File xcode6_0
-	File xcode5_1
+    static File xcode7_1_1 = new File(File.createTempDir(), "Xcode7.1.1.app")
+    static File xcode6_1 = new File(File.createTempDir(), "Xcode6-1.app")
+    static File xcode6_0 = new File(File.createTempDir(), "Xcode6.app")
+    static File xcode5_1 = new File(File.createTempDir(), "Xcode5.app")
 
-	def setup() {
+    def setup() {
+        xcode = Spy(Xcode, constructorArgs: [commandRunner])
 
-		xcode = new Xcode(commandRunner)
+        new File(xcode7_1_1, "Contents/Developer/usr/bin").mkdirs()
+        new File(xcode6_1, "Contents/Developer/usr/bin").mkdirs()
+        new File(xcode6_0, "Contents/Developer/usr/bin").mkdirs()
+        new File(xcode5_1, "Contents/Developer/usr/bin").mkdirs()
 
-		xcode7_1_1 = new File(System.getProperty("java.io.tmpdir"), "Xcode7.1.1.app")
-		xcode6_1 = new File(System.getProperty("java.io.tmpdir"), "Xcode6-1.app")
-		xcode6_0 = new File(System.getProperty("java.io.tmpdir"), "Xcode6.app")
-		xcode5_1 = new File(System.getProperty("java.io.tmpdir"), "Xcode5.app")
-		new File(xcode7_1_1, "Contents/Developer/usr/bin").mkdirs()
-		new File(xcode6_1, "Contents/Developer/usr/bin").mkdirs()
-		new File(xcode6_0, "Contents/Developer/usr/bin").mkdirs()
-		new File(xcode5_1, "Contents/Developer/usr/bin").mkdirs()
+        new File(xcode7_1_1, "Contents/Developer/usr/bin/xcodebuild").createNewFile()
+        new File(xcode6_1, "Contents/Developer/usr/bin/xcodebuild").createNewFile()
+        new File(xcode6_0, "Contents/Developer/usr/bin/xcodebuild").createNewFile()
+        new File(xcode5_1, "Contents/Developer/usr/bin/xcodebuild").createNewFile()
+    }
 
-		new File(xcode7_1_1, "Contents/Developer/usr/bin/xcodebuild").createNewFile()
-		new File(xcode6_1, "Contents/Developer/usr/bin/xcodebuild").createNewFile()
-		new File(xcode6_0, "Contents/Developer/usr/bin/xcodebuild").createNewFile()
-		new File(xcode5_1, "Contents/Developer/usr/bin/xcodebuild").createNewFile()
+    def cleanup() {
+        FileUtils.deleteDirectory(xcode7_1_1)
+        FileUtils.deleteDirectory(xcode6_1)
+        FileUtils.deleteDirectory(xcode6_0)
+        FileUtils.deleteDirectory(xcode5_1)
+    }
 
+    def "test default xcode path"() {
+        given:
+        useDefaultXcode()
 
-	}
+        expect:
+        xcode.getPath().equals("/Applications/Xcode.app")
+    }
 
-	def cleanup() {
-		FileUtils.deleteDirectory(xcode7_1_1)
-		FileUtils.deleteDirectory(xcode6_1)
-		FileUtils.deleteDirectory(xcode6_0)
-		FileUtils.deleteDirectory(xcode5_1)
-	}
+    def useXcode(String version) {
+        mockInstalledXcodeVersions()
 
-	def "test default xcode path"() {
-		given:
-		useDefaultXcode()
+        xcode = new Xcode(commandRunner, version)
+    }
 
-		expect:
-		xcode.getPath().equals("/Applications/Xcode.app")
+    def mockInstalledXcodeVersions() {
+        commandRunner.runWithResult(xcode5_1.absolutePath + "/Contents/Developer/usr/bin/xcodebuild", "-version") >> ("Xcode 5.1.1\nBuild version 5B1008")
+        commandRunner.runWithResult(xcode6_0.absolutePath + "/Contents/Developer/usr/bin/xcodebuild", "-version") >> ("Xcode 6.0\nBuild version 6A000")
+        commandRunner.runWithResult(xcode6_1.absolutePath + "/Contents/Developer/usr/bin/xcodebuild", "-version") >> ("Xcode 6.4\nBuild version 6E35b")
+        commandRunner.runWithResult(xcode7_1_1.absolutePath + "/Contents/Developer/usr/bin/xcodebuild", "-version") >> ("Xcode 7.1.1\nBuild version 7B1005")
+        commandRunner.runWithResult("mdfind", "kMDItemCFBundleIdentifier=com.apple.dt.Xcode") >> xcode5_1.absolutePath + "\n" + xcode6_0.absolutePath + "\n" + xcode6_1.absolutePath + "\n" + xcode7_1_1.absolutePath
+    }
 
-	}
+    def useDefaultXcode() {
+        commandRunner.runWithResult("xcode-select", "-p") >> ("/Applications/Xcode.app/Contents/Developer")
+    }
 
+    @Unroll
+    def "xcodebuild of Xcode 5 is used"() {
+        given:
+        useXcode("5B1008")
 
-	def useXcode(String version) {
-		commandRunner.runWithResult(xcode5_1.absolutePath + "/Contents/Developer/usr/bin/xcodebuild", "-version") >> ("Xcode 5.1.1\nBuild version 5B1008")
-		commandRunner.runWithResult(xcode6_0.absolutePath + "/Contents/Developer/usr/bin/xcodebuild", "-version") >> ("Xcode 6.0\nBuild version 6A000")
-		commandRunner.runWithResult(xcode6_1.absolutePath + "/Contents/Developer/usr/bin/xcodebuild", "-version") >> ("Xcode 6.4\nBuild version 6E35b")
-		commandRunner.runWithResult(xcode7_1_1.absolutePath + "/Contents/Developer/usr/bin/xcodebuild", "-version") >> ("Xcode 7.1.1\nBuild version 7B1005")
-		commandRunner.runWithResult("mdfind", "kMDItemCFBundleIdentifier=com.apple.dt.Xcode") >> xcode5_1.absolutePath + "\n"  + xcode6_0.absolutePath + "\n" + xcode6_1.absolutePath + "\n" +  xcode7_1_1.absolutePath
+        expect:
+        xcode.getXcodebuild()
+                .endsWith("Xcode5.app/Contents/Developer/usr/bin/xcodebuild")
 
-		xcode = new Xcode(commandRunner, version)
-	}
+        where:
+        version  | _
+        "5B1008" | _
+        "5.1"    | _
+        "5.1.1"  | _
+    }
 
+    def "xcodeVersion Simple not found"() {
+        when:
+        useXcode("5.1.2")
 
-	def useDefaultXcode() {
-		commandRunner.runWithResult("xcode-select", "-p") >> ("/Applications/Xcode.app/Contents/Developer")
-	}
+        then:
+        thrown(IllegalStateException)
+    }
 
-	def "xcodebuild of Xcode 5 is used"() {
-		given:
-		useXcode("5B1008")
+    def "xcodeVersion select last"() {
+        commandRunner.runWithResult("mdfind", "kMDItemCFBundleIdentifier=com.apple.dt.Xcode") >> xcode6_1.absolutePath + "\n" + xcode6_0.absolutePath + "\n" + xcode5_1.absolutePath
+        commandRunner.runWithResult(xcode6_1.absolutePath + "/Contents/Developer/usr/bin/xcodebuild", "-version") >> "Xcode 6.0\nBuild version 6A000"
+        commandRunner.runWithResult(xcode6_0.absolutePath + "/Contents/Developer/usr/bin/xcodebuild", "-version") >> "Xcode 6.0\nBuild version 6A000"
+        commandRunner.runWithResult(xcode5_1.absolutePath + "/Contents/Developer/usr/bin/xcodebuild", "-version") >> "Xcode 5.1.1\nBuild version 5B1008"
 
-		expect:
-		xcode.getXcodebuild().endsWith("Xcode5.app/Contents/Developer/usr/bin/xcodebuild")
-	}
+        when:
+        xcode = new Xcode(commandRunner, '5B1008')
 
-	def "xcodebuild of Xcode 5 simple version number"() {
-		given:
-		useXcode("5.1")
-
-		expect:
-		xcode.getXcodebuild().endsWith("Xcode5.app/Contents/Developer/usr/bin/xcodebuild")
-	}
-
-
-	def "xcode Version Simple 1"() {
-
-		given:
-		useXcode("5.1.1")
-
-		expect:
-		xcode.getXcodebuild().endsWith("Xcode5.app/Contents/Developer/usr/bin/xcodebuild")
-	}
-
-	def "xcodeVersion Simple not found"() {
-		when:
-		useXcode("5.1.2")
-
-		then:
-		thrown(IllegalStateException)
-	}
+        then:
+        xcode.getXcodebuild().endsWith("Xcode5.app/Contents/Developer/usr/bin/xcodebuild")
+    }
 
 
-	def "xcodeVersion select last"() {
-		commandRunner.runWithResult("mdfind", "kMDItemCFBundleIdentifier=com.apple.dt.Xcode") >>  xcode6_1.absolutePath + "\n"  + xcode6_0.absolutePath + "\n" + xcode5_1.absolutePath
-		commandRunner.runWithResult(xcode6_1.absolutePath + "/Contents/Developer/usr/bin/xcodebuild", "-version") >> "Xcode 6.0\nBuild version 6A000"
-		commandRunner.runWithResult(xcode6_0.absolutePath + "/Contents/Developer/usr/bin/xcodebuild", "-version") >> "Xcode 6.0\nBuild version 6A000"
-		commandRunner.runWithResult(xcode5_1.absolutePath + "/Contents/Developer/usr/bin/xcodebuild", "-version") >> "Xcode 5.1.1\nBuild version 5B1008"
+    def "xcodeVersion select not found"() {
+        useXcode("5B1008")
 
-		when:
-		xcode = new Xcode(commandRunner, '5B1008')
+        when:
+        xcode = new Xcode(commandRunner, '5B1009')
 
-		then:
-		xcode.getXcodebuild().endsWith("Xcode5.app/Contents/Developer/usr/bin/xcodebuild")
-	}
+        then:
+        thrown(IllegalStateException)
+    }
 
+    def "version is not null"() {
+        given:
+        commandRunner.runWithResult("xcodebuild", "-version") >> ("Xcode 7.3.1\nBuild version 7D1014")
 
-	def "xcodeVersion select not found"() {
-		useXcode("5B1008")
-
-		when:
-		xcode = new Xcode(commandRunner, '5B1009')
-
-		then:
-		thrown(IllegalStateException)
-	}
-
-	def "version is not null"() {
-		given:
-		commandRunner.runWithResult("xcodebuild", "-version") >> ("Xcode 7.3.1\nBuild version 7D1014")
-
-		expect:
-		xcode.getVersion() != null
-		xcode.getVersion().major == 7
-		xcode.getVersion().minor == 3
-		xcode.getVersion().maintenance == 1
-	}
+        expect:
+        xcode.getVersion() != null
+        xcode.getVersion().major == 7
+        xcode.getVersion().minor == 3
+        xcode.getVersion().maintenance == 1
+    }
 
 
-	def "altool default path"() {
-		given:
-		useDefaultXcode()
+    def "altool default path"() {
+        given:
+        useDefaultXcode()
 
-		expect:
-		xcode.getAltool() == '/Applications/Xcode.app/Contents/Applications/Application Loader.app/Contents/Frameworks/ITunesSoftwareService.framework/Support/altool'
-	}
+        expect:
+        xcode.getAltool() == '/Applications/Xcode.app/Contents/Applications/Application Loader.app/Contents/Frameworks/ITunesSoftwareService.framework/Support/altool'
+    }
 
-	def "altool with xcode 7.1.1"() {
-		given:
-		useXcode("7.1")
+    def "altool with xcode 7.1.1"() {
+        given:
+        useXcode("7.1")
 
-		expect:
-		xcode.getAltool().contains('Xcode7.1.1.app')
-		xcode.getAltool().endsWith('Contents/Applications/Application Loader.app/Contents/Frameworks/ITunesSoftwareService.framework/Support/altool')
-	}
+        expect:
+        xcode.getAltool().contains('Xcode7.1.1.app')
+        xcode.getAltool().endsWith('Contents/Applications/Application Loader.app/Contents/Frameworks/ITunesSoftwareService.framework/Support/altool')
+    }
 
-	def "xcrun default path"() {
-		given:
-		useDefaultXcode()
+    def "xcrun default path"() {
+        given:
+        useDefaultXcode()
 
-		expect:
-		xcode.getXcrun() == '/Applications/Xcode.app/Contents/Developer/usr/bin/xcrun'
-	}
-
-
-	def "xcrun with xcode 7.1.1"() {
-		given:
-		useXcode("7.1")
-
-		expect:
-		xcode.getXcrun().endsWith('Xcode7.1.1.app/Contents/Developer/usr/bin/xcrun')
-	}
+        expect:
+        xcode.getXcrun() == '/Applications/Xcode.app/Contents/Developer/usr/bin/xcrun'
+    }
 
 
+    def "xcrun with xcode 7.1.1"() {
+        given:
+        useXcode("7.1")
 
-	def "set xcode version"() {
-		useXcode("7.1")
+        expect:
+        xcode.getXcrun().endsWith('Xcode7.1.1.app/Contents/Developer/usr/bin/xcrun')
+    }
 
+    def "set xcode version"() {
+        setup:
+        useXcode(version)
 
-		expect:
-		xcode.version instanceof Version
-		xcode.version.major == 7
-		xcode.version.minor == 1
-		xcode.version.maintenance == 1
-	}
+        expect:
+        xcode.version instanceof Version
+        xcode.version.major == major
+        xcode.version.minor == minor
+        xcode.version.maintenance == maintenance
 
-	def "set xcode version with xcode 6"() {
-		useXcode("6.4")
+        where:
+        version | major | minor | maintenance
+        "5.1.1" | 5     | 1     | 1
+        "6.0"   | 6     | 0     | -1
+        "6.4"   | 6     | 4     | -1
+        "7.1.1" | 7     | 1     | 1
+    }
 
-		expect:
-		xcode.version instanceof Version
-		xcode.version.major == 6
-		xcode.version.minor == 4
-		xcode.version.maintenance == -1
-	}
+    def "get xcode version"() {
+        given:
+        commandRunner.runWithResult("xcodebuild", "-version") >> ("Xcode 6.4\nBuild version 6E35b")
 
-	def "get xcode version"() {
-		given:
-		commandRunner.runWithResult("xcodebuild", "-version") >> ("Xcode 6.4\nBuild version 6E35b")
+        when:
+        Version version = xcode.version
 
-		when:
-		Version version = xcode.version
-
-		then:
-		version instanceof Version
-		version.major == 6
-		version.minor == 4
-		version.maintenance == -1
-	}
-
-
-	def "simctl default path"() {
-		given:
-		useDefaultXcode()
-
-		expect:
-		xcode.getSimctl() == '/Applications/Xcode.app/Contents/Developer/usr/bin/simctl'
-	}
+        then:
+        version instanceof Version
+        version.major == 6
+        version.minor == 4
+        version.maintenance == -1
+    }
 
 
+    def "simctl default path"() {
+        given:
+        useDefaultXcode()
+
+        expect:
+        xcode.getSimctl() == '/Applications/Xcode.app/Contents/Developer/usr/bin/simctl'
+    }
+
+    def "Should be able to resolve a Xcode version by string without exception when valid"() {
+        when:
+        mockInstalledXcodeVersions()
+        xcode.setVersionFromString(version)
+
+        then:
+        1 * xcode.selectXcode(new File(file, Xcode.XCODE_CONTENT_XCODE_BUILD))
+        xcode.version.toString() == (version + "." + buildVersion)
+        noExceptionThrown()
+
+        where:
+        version | buildVersion | file
+        "5.1.1" | "5B1008"     | xcode5_1
+        "6.0"   | "6A000"      | xcode6_0
+        "7.1.1" | "7B1005"     | xcode7_1_1
+    }
+
+    def "Should raise an exception when resolving a invalid Xcode instance by version string"() {
+        when:
+        mockInstalledXcodeVersions()
+        xcode.setVersionFromString(version)
+
+        then:
+        thrown(exception)
+        0 * xcode.selectXcode(_)
+
+        where:
+        version | exception
+        "5.1.3" | IllegalStateException
+        "10.0"  | IllegalStateException
+        "7.1.3" | IllegalStateException
+        null    | IllegalArgumentException
+    }
+
+    def "Should return a map of environment values containing the developer dir key for valid xcode version"() {
+        when:
+        mockInstalledXcodeVersions()
+        Map<String, String> envValues = xcode.getXcodeSelectEnvValue(version)
+
+        then:
+        noExceptionThrown()
+        envValues.get(Xcode.ENV_DEVELOPER_DIR) == new File(file, Xcode.XCODE_CONTENT_DEVELOPER).absolutePath
+
+        where:
+        version | file
+        "5.1.1" | xcode5_1
+        "6.0"   | xcode6_0
+        "7.1.1" | xcode7_1_1
+    }
 }

--- a/plugin/src/main/groovy/org/openbakery/AbstractXcodeTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/AbstractXcodeTask.groovy
@@ -202,9 +202,13 @@ abstract class AbstractXcodeTask extends DefaultTask {
 
 	Xcode getXcode() {
 		if (xcode == null) {
-			xcode = new Xcode(commandRunner, project.xcodebuild.xcodeVersion)
+			xcode = new Xcode(commandRunner, getProjectXcodeVersion())
 		}
 		return xcode
+	}
+
+	String getProjectXcodeVersion() {
+		return project.xcodebuild.xcodeVersion
 	}
 
 	DestinationResolver getDestinationResolver() {

--- a/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
@@ -469,7 +469,7 @@ class XcodeBuildPluginExtension {
 			xcode = new Xcode(commandRunner, xcodeVersion)
 		}
 		logger.debug("using xcode {}", xcode)
- 		return xcode
+		return xcode
 	}
 
 

--- a/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
@@ -602,13 +602,11 @@ class XcodePlugin implements Plugin<Project> {
 
 	private configureCarthageDependencies(Project project) {
 		CarthageBootStrapTask bootStrapTask = project.getTasks().getByName(CARTHAGE_BOOTSTRAP_TASK_NAME)
-		if (bootStrapTask.hasCartFile()) {
-			addDependencyToBuild(project, bootStrapTask)
+		addDependencyToBuild(project, bootStrapTask)
 
-			project.getTasks()
-					.getByName(BasePlugin.CLEAN_TASK_NAME)
-					.dependsOn(project.getTasks().getByName(CARTHAGE_CLEAN_TASK_NAME))
-		}
+		project.getTasks()
+				.getByName(BasePlugin.CLEAN_TASK_NAME)
+				.dependsOn(project.getTasks().getByName(CARTHAGE_CLEAN_TASK_NAME))
 	}
 
 	private void configureOCLint(Project project) {

--- a/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
@@ -601,12 +601,13 @@ class XcodePlugin implements Plugin<Project> {
 	}
 
 	private configureCarthageDependencies(Project project) {
-		CarthageUpdateTask carthageUpdateTask = project.getTasks().getByName(XcodePlugin.CARTHAGE_UPDATE_TASK_NAME)
-		CarthageCleanTask carthageCleanTask = project.getTasks().getByName(XcodePlugin.CARTHAGE_CLEAN_TASK_NAME)
+		CarthageBootStrapTask bootStrapTask = project.getTasks().getByName(CARTHAGE_BOOTSTRAP_TASK_NAME)
+		if (bootStrapTask.hasCartFile()) {
+			addDependencyToBuild(project, bootStrapTask)
 
-		if (carthageUpdateTask.hasCartFile()) {
-			addDependencyToBuild(project, carthageUpdateTask)
-			project.getTasks().getByName(BasePlugin.CLEAN_TASK_NAME).dependsOn(carthageCleanTask);
+			project.getTasks()
+					.getByName(BasePlugin.CLEAN_TASK_NAME)
+					.dependsOn(project.getTasks().getByName(CARTHAGE_CLEAN_TASK_NAME))
 		}
 	}
 

--- a/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
@@ -27,6 +27,7 @@ import org.openbakery.appledoc.AppledocTask
 import org.openbakery.appstore.AppstorePluginExtension
 import org.openbakery.appstore.AppstoreValidateTask
 import org.openbakery.appstore.AppstoreUploadTask
+import org.openbakery.carthage.CarthageBootStrapTask
 import org.openbakery.carthage.CarthageCleanTask
 import org.openbakery.carthage.CarthageUpdateTask
 import org.openbakery.cocoapods.CocoapodsBootstrapTask
@@ -90,7 +91,7 @@ class XcodePlugin implements Plugin<Project> {
 
 	public static final String XCODE_TEST_TASK_NAME = "xcodetest"
 	public static final String XCODE_BUILD_FOR_TEST_TASK_NAME = "xcodebuildForTest"
-	public static final String XCODE_TEST_RUN_TASK_NAME =  "xcodetestrun"
+	public static final String XCODE_TEST_RUN_TASK_NAME = "xcodetestrun"
 	public static final String ARCHIVE_TASK_NAME = "archive"
 	public static final String SIMULATORS_LIST_TASK_NAME = "simulatorsList"
 	public static final String SIMULATORS_CREATE_TASK_NAME = "simulatorsCreate"
@@ -129,6 +130,7 @@ class XcodePlugin implements Plugin<Project> {
 	public static final String OCLINT_TASK_NAME = 'oclint'
 	public static final String OCLINT_REPORT_TASK_NAME = 'oclintReport'
 	public static final String CPD_TASK_NAME = 'cpd'
+	public static final String CARTHAGE_BOOTSTRAP_TASK_NAME = 'carthageBootstrap'
 	public static final String CARTHAGE_UPDATE_TASK_NAME = 'carthageUpdate'
 	public static final String CARTHAGE_CLEAN_TASK_NAME = 'carthageClean'
 
@@ -141,8 +143,6 @@ class XcodePlugin implements Plugin<Project> {
 
 
 	public static final String SDK_IPHONESIMULATOR = "iphonesimulator"
-
-
 
 
 	void apply(Project project) {
@@ -597,6 +597,7 @@ class XcodePlugin implements Plugin<Project> {
 	private void configureCarthage(Project project) {
 		project.task(CARTHAGE_CLEAN_TASK_NAME, type: CarthageCleanTask, group: CARTHAGE_GROUP_NAME)
 		project.task(CARTHAGE_UPDATE_TASK_NAME, type: CarthageUpdateTask, group: CARTHAGE_GROUP_NAME)
+		project.task(CARTHAGE_BOOTSTRAP_TASK_NAME, type: CarthageBootStrapTask, group: CARTHAGE_GROUP_NAME)
 	}
 
 	private configureCarthageDependencies(Project project) {
@@ -614,7 +615,7 @@ class XcodePlugin implements Plugin<Project> {
 
 		Task ocLintTask = project.getTasks().create(OCLINT_TASK_NAME);
 		ocLintTask.group = ANALYTICS_GROUP_NAME
-		ocLintTask.description = "Runs: " +  BasePlugin.CLEAN_TASK_NAME + " " + XCODE_BUILD_TASK_NAME + " " + OCLINT_REPORT_TASK_NAME
+		ocLintTask.description = "Runs: " + BasePlugin.CLEAN_TASK_NAME + " " + XCODE_BUILD_TASK_NAME + " " + OCLINT_REPORT_TASK_NAME
 		ocLintTask.dependsOn(project.getTasks().getByName(BasePlugin.CLEAN_TASK_NAME))
 
 		XcodeBuildTask xcodeBuildTask = project.getTasks().getByName(XcodePlugin.XCODE_BUILD_TASK_NAME)

--- a/plugin/src/main/groovy/org/openbakery/carthage/AbstractCarthageTaskBase.groovy
+++ b/plugin/src/main/groovy/org/openbakery/carthage/AbstractCarthageTaskBase.groovy
@@ -1,0 +1,89 @@
+package org.openbakery.carthage
+
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.*
+import org.openbakery.AbstractXcodeTask
+import org.openbakery.xcode.Type
+
+abstract class AbstractCarthageTaskBase extends AbstractXcodeTask {
+
+	static final String ACTION_BOOTSTRAP = "bootstrap"
+	static final String ACTION_UPDATE = "update"
+	static final String ARG_CACHE_BUILDS = "--cache-builds"
+	static final String ARG_PLATFORM = "--platform"
+	static final String CARTHAGE_FILE = "Cartfile"
+	static final String CARTHAGE_FILE_RESOLVED = "Cartfile.resolved"
+	static final String CARTHAGE_PLATFORM_IOS = "iOS"
+	static final String CARTHAGE_PLATFORM_MACOS = "Mac"
+	static final String CARTHAGE_PLATFORM_TVOS = "tvOS"
+	static final String CARTHAGE_PLATFORM_WATCHOS = "watchOS"
+	static final String CARTHAGE_USR_BIN_PATH = "/usr/local/bin/carthage"
+
+	AbstractCarthageTaskBase() {
+		super()
+	}
+
+	@InputFile
+	@Optional
+	@PathSensitive(PathSensitivity.RELATIVE)
+	Provider<File> getCartFile() {
+		// Cf https://github.com/gradle/gradle/issues/2016
+		File file = project.rootProject.file(CARTHAGE_FILE)
+		return project.provider {
+			file.exists() ? file
+					: File.createTempFile(CARTHAGE_FILE, "")
+		}
+	}
+
+	@InputFile
+	@Optional
+	@PathSensitive(PathSensitivity.RELATIVE)
+	Provider<File> getCartResolvedFile() {
+		// Cf https://github.com/gradle/gradle/issues/2016
+		File file = project.rootProject.file(CARTHAGE_FILE_RESOLVED)
+		return project.provider {
+			file.exists() ? file
+					: File.createTempFile(CARTHAGE_FILE_RESOLVED, "resolved")
+		}
+	}
+
+	@Input
+	String getCarthagePlatformName() {
+		switch (project.xcodebuild.type) {
+			case Type.iOS: return CARTHAGE_PLATFORM_IOS
+			case Type.tvOS: return CARTHAGE_PLATFORM_TVOS
+			case Type.macOS: return CARTHAGE_PLATFORM_MACOS
+			case Type.watchOS: return CARTHAGE_PLATFORM_WATCHOS
+			default: return 'all'
+		}
+	}
+
+	@OutputDirectory
+	Provider<File> getOutputDirectory() {
+		return project.provider {
+			project.rootProject.file("Carthage/Build/" + getCarthagePlatformName())
+		}
+	}
+
+	String getCarthageCommand() {
+		try {
+			return commandRunner.runWithResult("which", "carthage")
+		} catch (CommandRunnerException) {
+			// ignore, because try again with full path below
+		}
+
+		try {
+			commandRunner.runWithResult("ls", CARTHAGE_USR_BIN_PATH)
+			return CARTHAGE_USR_BIN_PATH
+		} catch (CommandRunnerException) {
+			// ignore, because blow an exception is thrown
+		}
+		throw new IllegalStateException("The carthage command was not found. Make sure that Carthage is installed")
+	}
+
+	boolean hasCartFile() {
+		return project.rootProject
+				.file(CARTHAGE_FILE)
+				.exists()
+	}
+}

--- a/plugin/src/main/groovy/org/openbakery/carthage/AbstractCarthageTaskBase.groovy
+++ b/plugin/src/main/groovy/org/openbakery/carthage/AbstractCarthageTaskBase.groovy
@@ -24,6 +24,7 @@ abstract class AbstractCarthageTaskBase extends AbstractXcodeTask {
 	}
 
 	@Input
+	@Optional
 	String getRequiredXcodeVersion() {
 		return getProjectXcodeVersion()
 	}

--- a/plugin/src/main/groovy/org/openbakery/carthage/AbstractCarthageTaskBase.groovy
+++ b/plugin/src/main/groovy/org/openbakery/carthage/AbstractCarthageTaskBase.groovy
@@ -23,6 +23,11 @@ abstract class AbstractCarthageTaskBase extends AbstractXcodeTask {
 		super()
 	}
 
+	@Input
+	String getRequiredXcodeVersion() {
+		return getProjectXcodeVersion()
+	}
+
 	@InputFile
 	@Optional
 	@PathSensitive(PathSensitivity.RELATIVE)

--- a/plugin/src/main/groovy/org/openbakery/carthage/CarthageBootStrapTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/carthage/CarthageBootStrapTask.groovy
@@ -4,25 +4,25 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.openbakery.output.ConsoleOutputAppender
 
-class CarthageUpdateTask extends AbstractCarthageTaskBase {
+class CarthageBootStrapTask extends AbstractCarthageTaskBase {
 
-	CarthageUpdateTask() {
+	CarthageBootStrapTask() {
 		super()
-		setDescription "Update and rebuild the Carthage project dependencies"
+		setDescription "Check out and build the Carthage project dependencies"
 	}
 
 	@TaskAction
 	void update() {
 		if (hasCartFile()) {
-			logger.info('Update Carthage for platform ' + carthagePlatformName)
+			logger.info('Boostrap Carthage for platform ' + carthagePlatformName)
 
 			def output = services.get(StyledTextOutputFactory)
-					.create(CarthageUpdateTask)
+					.create(CarthageBootStrapTask)
 
 			commandRunner.run(
 					project.projectDir.absolutePath,
 					[getCarthageCommand(),
-					 ACTION_UPDATE,
+					 ACTION_BOOTSTRAP,
 					 ARG_PLATFORM,
 					 carthagePlatformName,
 					 ARG_CACHE_BUILDS],

--- a/plugin/src/main/groovy/org/openbakery/carthage/CarthageBootStrapTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/carthage/CarthageBootStrapTask.groovy
@@ -15,7 +15,6 @@ class CarthageBootStrapTask extends AbstractCarthageTaskBase {
 	void update() {
 		if (hasCartFile()) {
 			logger.info('Boostrap Carthage for platform ' + carthagePlatformName)
-
 			def output = services.get(StyledTextOutputFactory)
 					.create(CarthageBootStrapTask)
 
@@ -26,6 +25,7 @@ class CarthageBootStrapTask extends AbstractCarthageTaskBase {
 					 ARG_PLATFORM,
 					 carthagePlatformName,
 					 ARG_CACHE_BUILDS],
+					xcode.getXcodeSelectEnvValue(project.xcodebuild.xcodeVersion),
 					new ConsoleOutputAppender(output))
 		}
 	}

--- a/plugin/src/main/groovy/org/openbakery/carthage/CarthageBootStrapTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/carthage/CarthageBootStrapTask.groovy
@@ -20,14 +20,15 @@ class CarthageBootStrapTask extends AbstractCarthageTaskBase {
 			def output = services.get(StyledTextOutputFactory)
 					.create(CarthageBootStrapTask)
 
-			commandRunner.run(
-					project.projectDir.absolutePath,
-					[getCarthageCommand(),
-					 ACTION_BOOTSTRAP,
-					 ARG_PLATFORM,
-					 carthagePlatformName,
-					 ARG_CACHE_BUILDS],
-					xcode.getXcodeSelectEnvValue(getRequiredXcodeVersion()),
+			List<String> args = [getCarthageCommand(),
+								 ACTION_BOOTSTRAP,
+								 ARG_PLATFORM,
+								 carthagePlatformName,
+								 ARG_CACHE_BUILDS]
+
+			commandRunner.run(project.projectDir.absolutePath,
+					args,
+					getRequiredXcodeVersion() != null ? xcode.getXcodeSelectEnvValue(getRequiredXcodeVersion()) : null,
 					new ConsoleOutputAppender(output))
 		}
 	}

--- a/plugin/src/main/groovy/org/openbakery/carthage/CarthageBootStrapTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/carthage/CarthageBootStrapTask.groovy
@@ -1,9 +1,11 @@
 package org.openbakery.carthage
 
+import groovy.transform.CompileStatic
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.openbakery.output.ConsoleOutputAppender
 
+@CompileStatic
 class CarthageBootStrapTask extends AbstractCarthageTaskBase {
 
 	CarthageBootStrapTask() {
@@ -25,7 +27,7 @@ class CarthageBootStrapTask extends AbstractCarthageTaskBase {
 					 ARG_PLATFORM,
 					 carthagePlatformName,
 					 ARG_CACHE_BUILDS],
-					xcode.getXcodeSelectEnvValue(project.xcodebuild.xcodeVersion),
+					xcode.getXcodeSelectEnvValue(getRequiredXcodeVersion()),
 					new ConsoleOutputAppender(output))
 		}
 	}

--- a/plugin/src/main/groovy/org/openbakery/carthage/CarthageCleanTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/carthage/CarthageCleanTask.groovy
@@ -14,6 +14,4 @@ class CarthageCleanTask extends DefaultTask {
 	def clean() {
 		project.file("Carthage").deleteDir()
 	}
-
-
 }

--- a/plugin/src/main/groovy/org/openbakery/output/ConsoleOutputAppender.java
+++ b/plugin/src/main/groovy/org/openbakery/output/ConsoleOutputAppender.java
@@ -15,7 +15,6 @@ public class ConsoleOutputAppender implements OutputAppender {
 	@Override
 	public void append(String line) {
 		output.withStyle(StyledTextOutput.Style.Info).println(line);
-
 	}
 
 }

--- a/plugin/src/test/groovy/org/openbakery/XcodeBuildArchiveTaskSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/XcodeBuildArchiveTaskSpecification.groovy
@@ -33,7 +33,6 @@ class XcodeBuildArchiveTaskSpecification extends Specification {
 	PlistHelperStub plistHelper = new PlistHelperStub()
 
 	def setup() {
-
 		String tmpName =  "gradle-xcodebuild-" + RandomStringUtils.randomAlphanumeric(5)
 		projectDir = new File(System.getProperty("java.io.tmpdir"), tmpName)
 		project = ProjectBuilder.builder().withProjectDir(projectDir).build()

--- a/plugin/src/test/groovy/org/openbakery/XcodePluginSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/XcodePluginSpecification.groovy
@@ -286,7 +286,7 @@ class XcodePluginSpecification extends Specification {
 		project.tasks.findByName('carthageUpdate') instanceof CarthageUpdateTask
 	}
 
-	def "xcodebuild has carthage dependency"() {
+	def "xcodebuild has carthage bootstrap dependency"() {
 		when:
 		File projectDir = new File("../example/iOS/Example")
 		project = ProjectBuilder.builder().withProjectDir(projectDir).build()
@@ -298,13 +298,18 @@ class XcodePluginSpecification extends Specification {
 
 		then:
 
-		task.getTaskDependencies().getDependencies() contains(project.getTasks().getByName(XcodePlugin.CARTHAGE_UPDATE_TASK_NAME))
+		task.getTaskDependencies().getDependencies() contains(project.getTasks().getByName(XcodePlugin.CARTHAGE_BOOTSTRAP_TASK_NAME))
 	}
 
 
 	def "has carthage clean task"() {
 		expect:
 		project.tasks.findByName('carthageClean') instanceof CarthageCleanTask
+	}
+
+	def "has carthage update task"() {
+		expect:
+		project.tasks.findByName('carthageUpdate') instanceof CarthageUpdateTask
 	}
 
 	def "clean has carthage clean dependency"() {

--- a/plugin/src/test/groovy/org/openbakery/carthage/CarthageBootStrapTaskTest.groovy
+++ b/plugin/src/test/groovy/org/openbakery/carthage/CarthageBootStrapTaskTest.groovy
@@ -1,0 +1,121 @@
+package org.openbakery.carthage
+
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.rules.ExpectedException
+import org.openbakery.CommandRunner
+import org.openbakery.output.ConsoleOutputAppender
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static org.openbakery.carthage.AbstractCarthageTaskBase.*
+import static org.openbakery.xcode.Type.*
+
+class CarthageBootStrapTaskTest extends Specification {
+
+	CarthageBootStrapTask subject
+	CommandRunner commandRunner = Mock(CommandRunner)
+	File projectDir
+	File cartFile
+	Project project
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none()
+
+	void setup() {
+		projectDir = File.createTempDir()
+
+		cartFile = new File(projectDir, "Cartfile")
+		cartFile << 'github "Alamofire/Alamofire"'
+
+		project = ProjectBuilder.builder()
+				.withProjectDir(projectDir)
+				.build()
+
+		project.buildDir = new File(projectDir, 'build').absoluteFile
+		project.apply plugin: org.openbakery.XcodePlugin
+
+		subject = project.getTasks().getByPath('carthageBootstrap')
+		assert subject != null
+
+		subject.commandRunner = commandRunner
+	}
+
+	def "The carthage bootstrap task should be present"() {
+		expect:
+		subject instanceof CarthageBootStrapTask
+	}
+
+	@Unroll
+	def "When bootstrap is executed should only update the platform: #platform"() {
+		given:
+		commandRunner.runWithResult("which", "carthage") >> "/usr/local/bin/carthage"
+		project.xcodebuild.type = platform
+
+		when:
+		subject.update()
+
+		then:
+		1 * commandRunner.run(_,
+				[CARTHAGE_USR_BIN_PATH,
+				 ACTION_BOOTSTRAP,
+				 ARG_PLATFORM,
+				 carthagePlatform,
+				 ARG_CACHE_BUILDS]
+				, _) >> {
+			args -> args[2] instanceof ConsoleOutputAppender
+		}
+
+		where:
+		platform | carthagePlatform
+		tvOS     | CARTHAGE_PLATFORM_TVOS
+		macOS    | CARTHAGE_PLATFORM_MACOS
+		watchOS  | CARTHAGE_PLATFORM_WATCHOS
+		iOS      | CARTHAGE_PLATFORM_IOS
+	}
+
+	def "The task should not be executed if the 'Cartfile` file is missing"() {
+		given:
+		commandRunner.runWithResult("which", "carthage") >> "/usr/local/bin/carthage"
+		project.xcodebuild.type = platform
+
+		when:
+		cartFile.delete()
+		subject.update()
+
+		then:
+		0 * commandRunner.run(_, [CARTHAGE_USR_BIN_PATH,
+								  ACTION_UPDATE,
+								  ARG_PLATFORM,
+								  carthagePlatform,
+								  ARG_CACHE_BUILDS], _) >> {
+			args -> args[2] instanceof ConsoleOutputAppender
+		}
+
+		where:
+		platform | carthagePlatform
+		tvOS     | CARTHAGE_PLATFORM_TVOS
+		macOS    | CARTHAGE_PLATFORM_MACOS
+		watchOS  | CARTHAGE_PLATFORM_WATCHOS
+		iOS      | CARTHAGE_PLATFORM_IOS
+	}
+
+	def "The subject output directory should be platform dependant"() {
+		when:
+		project.xcodebuild.type = platform
+
+		then:
+		Provider<File> outputDirectory = subject.outputDirectory
+		outputDirectory.isPresent()
+		outputDirectory.get().name == carthagePlatform
+
+		where:
+		platform | carthagePlatform
+		tvOS     | CARTHAGE_PLATFORM_TVOS
+		macOS    | CARTHAGE_PLATFORM_MACOS
+		watchOS  | CARTHAGE_PLATFORM_WATCHOS
+		iOS      | CARTHAGE_PLATFORM_IOS
+	}
+}

--- a/plugin/src/test/groovy/org/openbakery/carthage/CarthageUpdateTaskSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/carthage/CarthageUpdateTaskSpecification.groovy
@@ -23,7 +23,7 @@ class CarthageUpdateTaskSpecification extends Specification {
 	CommandRunner commandRunner = Mock(CommandRunner)
 
 	@Rule
-	public ExpectedException exception = ExpectedException.none();
+	public ExpectedException exception = ExpectedException.none()
 
 	def setup() {
 		projectDir = File.createTempDir()


### PR DESCRIPTION
- Carthage action `bootstrap` and not `update` should be a build dependency
- Add a new bootstrap task to the  Carthage task group


bootstrap reads Cartfile.resolved, checks out and builds the dependencies at the versions listed.

update reads Cartfile and runs the dependency resolver to check out dependencies recursively, generally aiming for the newest versions that are compatible with all constraints in the tree. It writes Cartfile.resolved.

It too now setup the Xcode `DEVELOPER_DIR` environment variable which allow to make carthage use the defined version of xcode  in the model (if any)

So, if you're updating to newer dependencies, or you've edited your Cartfile, use update. If you've just checked out your project and want the dependencies as specified in the commit you're on, use bootstrap.