### PR TITLE
🐛 Use project's requested destinations in xcodebuildForTest

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = tab
+indent_size = tab
+tab_width = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.json]
+insert_final_newline = ignore
+
+[*.md]
+trim_trailing_whitespace = false
+

--- a/libxcode/src/main/groovy/org/openbakery/xcode/DestinationResolver.groovy
+++ b/libxcode/src/main/groovy/org/openbakery/xcode/DestinationResolver.groovy
@@ -10,10 +10,9 @@ class DestinationResolver {
 
 	SimulatorControl simulatorControl
 
-	public DestinationResolver(SimulatorControl simulatorControl) {
+	DestinationResolver(SimulatorControl simulatorControl) {
 		this.simulatorControl = simulatorControl
 	}
-
 
 	List<Destination> allFor(XcodebuildParameters parameters) {
 		if (parameters.type == Type.iOS && !parameters.simulator) {
@@ -33,8 +32,6 @@ class DestinationResolver {
 
 		def allDestinations = allFor(parameters)
 		def runtime = simulatorControl.getMostRecentRuntime(parameters.type)
-
-
 
 		if (isSimulatorFor(parameters)) {
 			// filter only on simulator builds
@@ -60,21 +57,20 @@ class DestinationResolver {
 
 				logger.info("There was no destination configured that matches the available. Therefor all available destinations where taken.")
 
-
 				switch (parameters.devices) {
 					case Devices.PHONE:
 						availableDestinations = allDestinations.findAll {
-							d -> d.name.contains("iPhone");
-						};
-						break;
+							d -> d.name.contains("iPhone")
+						}
+						break
 					case Devices.PAD:
 						availableDestinations = allDestinations.findAll {
-							d -> d.name.contains("iPad");
-						};
-						break;
+							d -> d.name.contains("iPad")
+						}
+						break
 					default:
-						availableDestinations.addAll(allDestinations);
-						break;
+						availableDestinations.addAll(allDestinations)
+						break
 				}
 			}
 		} else if (parameters.configuredDestinations != null) {
@@ -94,7 +90,7 @@ class DestinationResolver {
 	}
 
 	private List<Destination> findMatchingDestinations(Destination destination, List<Destination> allDestinations) {
-		def result = [];
+		List<Destination> result = []
 
 		logger.debug("finding matching destination for: {}", destination)
 
@@ -123,31 +119,28 @@ class DestinationResolver {
 			logger.debug("FOUND matching destination: {}", device)
 
 			result << device
-
 		}
 
-		return result.asList();
+		return result
 	}
 
-
-	private boolean matches(String first, String second) {
+	private static boolean matches(String first, String second) {
 		if (first != null && second == null) {
-			return true;
+			return true
 		}
 
 		if (first == null && second != null) {
-			return true;
+			return true
 		}
 
-		if (first.equals(second)) {
-			return true;
+		if (first == second) {
+			return true
 		}
 
 		if (second.matches(first)) {
-			return true;
+			return true
 		}
 
-		return false;
-
+		return false
 	}
 }

--- a/plugin/src/main/groovy/org/openbakery/XcodeBuildForTestTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeBuildForTestTask.groovy
@@ -2,6 +2,8 @@ package org.openbakery
 
 import org.apache.commons.configuration.plist.XMLPropertyListConfiguration
 import org.gradle.api.tasks.TaskAction
+import org.openbakery.xcode.Destination
+import org.openbakery.xcode.Type
 import org.openbakery.xcode.Xcodebuild
 
 class XcodeBuildForTestTask extends AbstractXcodeBuildTask {
@@ -14,11 +16,19 @@ class XcodeBuildForTestTask extends AbstractXcodeBuildTask {
 			XcodePlugin.XCODE_CONFIG_TASK_NAME,
 			XcodePlugin.SIMULATORS_KILL_TASK_NAME
 		)
-		this.description = "Build the xcode project and the tests. A testbundle is created that contains the result.	"
+		this.description = "Builds the xcode project and test target. Creates a testbundle that contains the result."
 	}
 
 	Xcodebuild getXcodebuild() {
-		return new Xcodebuild(project.projectDir, commandRunner, xcode, parameters, getDestinationResolver().allFor(parameters))
+		// Start with the destinations requested by the project
+		List<Destination> destinations = getDestinations()
+
+		if (parameters.type == Type.tvOS) {
+			// Get all destinations available for tvOS projects
+			destinations = getDestinationResolver().allFor(parameters)
+		}
+
+		return new Xcodebuild(project.projectDir, commandRunner, xcode, parameters, destinations)
 	}
 
 	@TaskAction
@@ -26,18 +36,18 @@ class XcodeBuildForTestTask extends AbstractXcodeBuildTask {
 		parameters = project.xcodebuild.xcodebuildParameters.merge(parameters)
 
 		if (parameters.scheme == null && parameters.target == null) {
-			throw new IllegalArgumentException("No 'scheme' or 'target' specified, so do not know what to build");
+			throw new IllegalArgumentException("No 'scheme' or 'target' specified, so do not know what to build")
 		}
 
-		outputDirectory = new File(project.getBuildDir(), "for-testing");
+		outputDirectory = new File(project.getBuildDir(), "for-testing")
 		if (!outputDirectory.exists()) {
 			outputDirectory.mkdirs()
 		}
 
 		File outputFile = new File(outputDirectory, "xcodebuild-output.txt")
-		commandRunner.setOutputFile(outputFile);
+		commandRunner.setOutputFile(outputFile)
 
-		xcodebuild.executeBuildForTesting(createXcodeBuildOutputAppender("XcodeBuildForTestTask") , project.xcodebuild.environment)
+		xcodebuild.executeBuildForTesting(createXcodeBuildOutputAppender("XcodeBuildForTestTask"), project.xcodebuild.environment)
 
 		createTestBundle()
 	}

--- a/plugin/src/test/groovy/org/openbakery/XcodeBuildForTestTaskSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/XcodeBuildForTestTaskSpecification.groovy
@@ -17,8 +17,7 @@ import spock.lang.Specification
 class XcodeBuildForTestTaskSpecification extends Specification {
 
 	Project project
-	CommandRunner commandRunner = Mock(CommandRunner);
-
+	CommandRunner commandRunner = Mock(CommandRunner)
 
 	XcodeBuildForTestTask xcodeBuildForTestTask
 
@@ -26,14 +25,13 @@ class XcodeBuildForTestTaskSpecification extends Specification {
 		project = ProjectBuilder.builder().build()
 		project.buildDir = new File(System.getProperty("java.io.tmpdir"), "gradle-xcodebuild/build")
 
-		project.apply plugin: org.openbakery.XcodePlugin
+		project.apply plugin: XcodePlugin
 
 		xcodeBuildForTestTask = project.getTasks().getByPath(XcodePlugin.XCODE_BUILD_FOR_TEST_TASK_NAME)
 		xcodeBuildForTestTask.commandRunner = commandRunner
 		xcodeBuildForTestTask.xcode = new XcodeFake()
 		xcodeBuildForTestTask.destinationResolver = new DestinationResolver(new SimulatorControlStub("simctl-list-xcode8.txt"))
 		project.xcodebuild.plistHelper = new PlistHelperStub()
-
 	}
 
 	def cleanup() {
@@ -44,9 +42,7 @@ class XcodeBuildForTestTaskSpecification extends Specification {
 	def "instance is of type XcodeBuildForTestTask"() {
 		expect:
 		xcodeBuildForTestTask instanceof  XcodeBuildForTestTask
-
 	}
-
 
 	def "depends on"() {
 		when:
@@ -58,12 +54,10 @@ class XcodeBuildForTestTaskSpecification extends Specification {
 		dependsOn.contains(XcodePlugin.SIMULATORS_KILL_TASK_NAME)
 	}
 
-
 	def "has xcodebuild"() {
 		expect:
 		xcodeBuildForTestTask.xcodebuild instanceof Xcodebuild
 	}
-
 
 	def "xcodebuild has merged parameters"() {
 		when:
@@ -87,7 +81,6 @@ class XcodeBuildForTestTaskSpecification extends Specification {
 		givenOutputFile == new File(project.getBuildDir(), "for-testing/xcodebuild-output.txt")
 	}
 
-
 	def "IllegalArgumentException_when_no_scheme_or_target_given"() {
 		when:
 		xcodeBuildForTestTask.buildForTest()
@@ -96,8 +89,7 @@ class XcodeBuildForTestTaskSpecification extends Specification {
 		thrown(IllegalArgumentException)
 	}
 
-
-	def "xcodebuild is exectued"() {
+	def "xcodebuild is executed"() {
 		def commandList
 		project.xcodebuild.scheme = 'myscheme'
 
@@ -108,7 +100,6 @@ class XcodeBuildForTestTaskSpecification extends Specification {
 		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
 		commandList.contains("build-for-testing")
 		commandList.contains("myscheme")
-
 	}
 
 	def "has output appender"() {
@@ -132,7 +123,22 @@ class XcodeBuildForTestTaskSpecification extends Specification {
 		then:
 		destinations.size() == 14
 		destinations[0].platform == "iOS Simulator"
+	}
 
+	def "xcodebuild has only the project's configured iOS destination"() {
+		when:
+		Destination destination = new Destination()
+		destination.platform = "iOS Simulator"
+		destination.name = "iPhone X"
+		destination.os = "11.3"
+		xcodeBuildForTestTask.parameters.destination = destination
+		def destinations = xcodeBuildForTestTask.xcodebuild.destinations
+
+		then:
+		destinations.size() == 1
+		destinations[0].platform == "iOS Simulator"
+		destinations[0].name == "iPhone X"
+		destinations[0].os == "11.3"
 	}
 
 	def "xcodebuild has all available iOS destinations for most recent runtime"() {
@@ -150,10 +156,9 @@ class XcodeBuildForTestTaskSpecification extends Specification {
 		destinations.size() == 12
 		destinations[0].platform == "iOS Simulator"
 		destinations[0].os == "9.1"
-
 	}
 
-	def "xcodebuild has all available iOS destinations with multiple SDKs "() {
+	def "xcodebuild has all available iOS destinations with multiple SDKs"() {
 		when:
 		xcodeBuildForTestTask.parameters.simulator = true
 		xcodeBuildForTestTask.parameters.type = Type.iOS
@@ -165,7 +170,6 @@ class XcodeBuildForTestTaskSpecification extends Specification {
 		destinations.size() == 22
 		destinations[0].platform == "iOS Simulator"
 		destinations[0].os == "9.1"
-
 	}
 
 	def "xcodebuild has all available tvOS destinations"() {
@@ -187,7 +191,6 @@ class XcodeBuildForTestTaskSpecification extends Specification {
 		then:
 		destinations.size() == 0
 	}
-
 
 	def "has test bundle as result for iOS Simulator"() {
 		project.xcodebuild.target = 'myscheme'
@@ -234,8 +237,6 @@ class XcodeBuildForTestTaskSpecification extends Specification {
 		new File(project.getBuildDir(), "for-testing/Example-iOS.testbundle").exists()
 	}
 
-
-
 	def "has app in test bundle"() {
 		given:
 		project.xcodebuild.target = 'myscheme'
@@ -247,7 +248,6 @@ class XcodeBuildForTestTaskSpecification extends Specification {
 		File sym = TestHelper.createDummyApp(new File(symDirectory, "Test-iphonesimulator"), "Example")
 		File xctestrun = new File("src/test/Resource/Example_iphonesimulator.xctestrun")
 		FileUtils.copyFile(xctestrun, new File(symDirectory, "Example_iphonesimulator.xctestrun"))
-
 
 		xcodeBuildForTestTask.parameters.symRoot = sym
 
@@ -261,6 +261,4 @@ class XcodeBuildForTestTaskSpecification extends Specification {
 		new File(testBundle, "Test-iphonesimulator/Example.app").exists()
 		new File(testBundle, "Example_iphonesimulator.xctestrun").exists()
 	}
-
-
 }


### PR DESCRIPTION
We are trying to use the `xcodebuildForTest` task to separate the building of the app from the actual testing. However, it is always failing because it attempts to target all iOS simulators and two invalid destinations:

- Generic iOS Device
- Generic iOS Simulator Device

This PR changes the `xcodebuildForTest` task to use the same destinations that are configured by the project. However, I left the "use all available destinations" in place for tvOS projects because it caused a test to break. I'm guessing there might be a valid case for this on tvOS but can revise this if necessary.

## Error

```
> Task :xcodebuildForTest FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':xcodebuildForTest'.
> Command failed to run (exit code 70): 'script -q /dev/null /Applications/Xcode-9.3.app/Contents/Developer/usr/bin/xcodebuild -scheme MDK -workspace MDK.xcworkspace -configuration Debug -destination platform=iOS Simulator,id=97FC1F45-1C3A-4B34-9FFD-2C496551624C -destination platform=iOS Simulator,id=8AFCEC87-69F0-4888-930C-FC815AF60420 -destination platform=iOS Simulator,id=CBC7702F-D3E1-4722-BBE8-99099608B4D1 -destination platform=iOS Simulator,id=667D99BC-6025-4BE7-A877-79E469B48AF8 -destination platform=iOS Simulator,id=DE17DB9D-CD64-4AFD-8BBD-DA9FFF056381 -destination platform=iOS Simulator,id=BFA98BF2-92A6-47F1-A9C0-68D99ADD6D08 -destination platform=iOS Simulator,id=9CE234B5-B8DD-49D6-8170-2A2048E3EE60 -destination platform=iOS Simulator,id=B62DEF11-90AE-426D-8304-4DF1AE331BF5 -destination platform=iOS Simulator,id=E6DD8E7C-1F50-4C88-993E-EAA4CFEE5917 -destination platform=iOS Simulator,id=5C4A02A2-CC90-4681-809A-45AA900ADECF -destination platform=iOS Simulator,id=6A6F0065-3BB7-4F81-878F-26DB7315DB0E -destination platform=iOS Simulator,id=FA677010-08A3-4FBF-82F3-ACAA66ACD14B -destination platform=iOS Simulator,id=0C5993AF-D515-415E-9CA8-FADC6630E8F4 -destination platform=iOS Simulator,id=FAE9D658-A5B2-422B-9A3E-1CF7231F5964 -destination platform=iOS Simulator,id=3839E804-A633-4971-9988-4D50C31EF74A -destination platform=iOS Simulator,id=BFD07623-E13E-487E-BC19-B8F86E97ACEB -destination platform=iOS Simulator,id=31C92D1B-8362-49BD-AF91-EB6FD2E9DA27 -destination platform=iOS Simulator,id=66643B4C-4405-4D49-9940-BE9B1E41722F -destination platform=iOS Simulator,id=973D8168-B4EE-43B0-B193-F25885ADB31D -destination platform=iOS Simulator,id=5C9E4BB0-EDD2-4B41-9091-B078A1B672EF -destination platform=iOS Simulator,id=304F561B-9A2D-4712-916A-358606B4B51E -destination platform=iOS Simulator,id=AFDE7328-2AA5-4E5C-925A-FB2934CE924B -destination platform=iOS Simulator,id=5216D9CD-3254-413D-929A-357A976F7093 -destination platform=iOS Simulator,id=2EBC821D-A669-4589-8648-CE42B3589E19 -destination platform=iOS Simulator,id=C3D62466-FEA5-41D4-87F9-1C834BE6D007 -destination platform=iOS Simulator,id=48D6EBCD-0E9A-4D43-B030-CAA894EFFAD0 -derivedDataPath /Volumes/ThunderBay/Users/phatblat/dev/ios/pods/MDKApp/build/derivedData DSTROOT=/Volumes/ThunderBay/Users/phatblat/dev/ios/pods/MDKApp/build/dst OBJROOT=/Volumes/ThunderBay/Users/phatblat/dev/ios/pods/MDKApp/build/obj SYMROOT=/Volumes/ThunderBay/Users/phatblat/dev/ios/pods/MDKApp/build/sym SHARED_PRECOMPS_DIR=/Volumes/ThunderBay/Users/phatblat/dev/ios/pods/MDKApp/build/shared -enableCodeCoverage yes build-for-testing'
  Tail of output:
                { platform:iOS Simulator, id:0C5993AF-D515-415E-9CA8-FADC6630E8F4, OS:11.3, name:iPad Air 2 }
                { platform:iOS Simulator, id:3839E804-A633-4971-9988-4D50C31EF74A, OS:11.3, name:iPad Pro (9.7-inch) }
                { platform:iOS Simulator, id:66643B4C-4405-4D49-9940-BE9B1E41722F, OS:11.3, name:iPad Pro (10.5-inch) }
                { platform:iOS Simulator, id:BFD07623-E13E-487E-BC19-B8F86E97ACEB, OS:11.3, name:iPad Pro (12.9-inch) }
                { platform:iOS Simulator, id:31C92D1B-8362-49BD-AF91-EB6FD2E9DA27, OS:11.3, name:iPad Pro (12.9-inch) (2nd generation) }
                { platform:iOS Simulator, id:97FC1F45-1C3A-4B34-9FFD-2C496551624C, OS:11.3, name:iPhone 5s }
                { platform:iOS Simulator, id:8AFCEC87-69F0-4888-930C-FC815AF60420, OS:11.3, name:iPhone 6 }
                { platform:iOS Simulator, id:CBC7702F-D3E1-4722-BBE8-99099608B4D1, OS:11.3, name:iPhone 6 Plus }
                { platform:iOS Simulator, id:667D99BC-6025-4BE7-A877-79E469B48AF8, OS:11.3, name:iPhone 6s }
                { platform:iOS Simulator, id:DE17DB9D-CD64-4AFD-8BBD-DA9FFF056381, OS:11.3, name:iPhone 6s Plus }
                { platform:iOS Simulator, id:BFA98BF2-92A6-47F1-A9C0-68D99ADD6D08, OS:11.3, name:iPhone 7 }
                { platform:iOS Simulator, id:9CE234B5-B8DD-49D6-8170-2A2048E3EE60, OS:11.3, name:iPhone 7 Plus }
                { platform:iOS Simulator, id:B62DEF11-90AE-426D-8304-4DF1AE331BF5, OS:11.3, name:iPhone 8 }
                { platform:iOS Simulator, id:E6DD8E7C-1F50-4C88-993E-EAA4CFEE5917, OS:11.3, name:iPhone 8 Plus }
                { platform:iOS Simulator, id:5C4A02A2-CC90-4681-809A-45AA900ADECF, OS:11.3, name:iPhone SE }
                { platform:iOS Simulator, id:6A6F0065-3BB7-4F81-878F-26DB7315DB0E, OS:11.3, name:iPhone X }

        Ineligible destinations for the "MDK" scheme:
                { platform:iOS, id:dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder, name:Generic iOS Device }
                { platform:iOS Simulator, id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder, name:Generic iOS Simulator Device }
```

Xcode 9.3 was used in this example.