### PR TITLE
Fixes packaging for non-fat binaries

### DIFF
--- a/libxcodetools/src/main/kotlin/org/openbakery/tools/Lipo.kt
+++ b/libxcodetools/src/main/kotlin/org/openbakery/tools/Lipo.kt
@@ -18,10 +18,8 @@ open class Lipo(xcode: Xcode, commandRunner: CommandRunner) {
 		)
 		var result = commandRunner.runWithResult(commandList)
 		if (result != null) {
-			var resultArray = result.split(" are: ")
-			if (resultArray.size == 2) {
-				return resultArray[1].split(" ")
-			}
+			var archsString = result.split(":").last().trim()
+			return archsString.split(" ")
 		}
 		return listOf("armv7", "arm64")
 	}
@@ -41,12 +39,8 @@ open class Lipo(xcode: Xcode, commandRunner: CommandRunner) {
 
 		val archs = getArchs(binary).toMutableList()
 		archs.removeAll(supportedArchs)
-
 		archs.iterator().forEach {
 			removeArch(binary, it)
 		}
-
-
 	}
-
 }


### PR DESCRIPTION
Since #402 has been merged, the packaging task is broken if the app has only one supported architecture. 
This is the case, if the deployment target of the app is >= iOS 11.0.
This happens, because the output of `lipo` contains trailing spaces and does not include ` are: `, so the parsing of the output would produce an array that included an empty string.

This PR updates how the results of `lipo` are parsed to handle this edge case. Additionally, the tests have been update to be more strict and catch edge cases like this.