### PR TITLE
Adds missing architecture for arm64-only builds

### DIFF
--- a/libxcodetools/src/main/kotlin/org/openbakery/assemble/AppPackage.kt
+++ b/libxcodetools/src/main/kotlin/org/openbakery/assemble/AppPackage.kt
@@ -114,8 +114,10 @@ class AppPackage(applicationBundle: ApplicationBundle, archive: File, codesignPa
 
 
 	fun updateArchsForSwiftLibs(frameworksPath : File) {
-		val binaryArchs = tools.lipo.getArchs(applicationBundle.mainBundle.executable).toMutableList()
-		binaryArchs.add("armv7s")
+		val binaryArchs = tools.lipo.getArchs(applicationBundle.mainBundle.executable)
+			.plus(listOf("armv7", "armv7s"))
+			.distinct()
+
 		for (file in frameworksPath.listFiles()) {
 			if (file.extension == "dylib") {
 				tools.lipo.removeUnsupportedArchs(file, binaryArchs)

--- a/libxcodetools/src/test/groovy/org/openbakery/assemble/AppPackageSpecification.groovy
+++ b/libxcodetools/src/test/groovy/org/openbakery/assemble/AppPackageSpecification.groovy
@@ -60,7 +60,7 @@ class AppPackageSpecification extends Specification {
 	}
 
 
-	def "remove archs from swift dynlib"() {
+	def "remove archs from swift dynlib for app archs armv7 & arm64"() {
 		given:
 		lipo.getArchs(new File(applicationPath, "ExampleExecutable")) >> ["armv7", "arm64"]
 
@@ -71,7 +71,7 @@ class AppPackageSpecification extends Specification {
 		1 * lipo.removeUnsupportedArchs(new File(applicationPath, "Frameworks/libswiftCore.dylib"), ["armv7", "arm64", "armv7s"])
 	}
 
-	def "remove archs from swift dynlib second"() {
+	def "remove archs from swift dynlib for app arch armv7"() {
 		given:
 		lipo.getArchs(new File(applicationPath, "ExampleExecutable")) >> ["armv7"]
 
@@ -82,6 +82,16 @@ class AppPackageSpecification extends Specification {
 		1 * lipo.removeUnsupportedArchs(new File(applicationPath, "Frameworks/libswiftCoreGraphics.dylib"), ["armv7", "armv7s"])
 	}
 
+	def "remove archs from swift dynlib for app arch armv64"() {
+		given:
+		lipo.getArchs(new File(applicationPath, "ExampleExecutable")) >> ["arm64"]
+
+		when:
+		appPackage.addSwiftSupport()
+
+		then:
+		1 * lipo.removeUnsupportedArchs(new File(applicationPath, "Frameworks/libswiftCoreGraphics.dylib"), ["arm64", "armv7", "armv7s"])
+	}
 
 	def "remove archs only from dylibs"() {
 		given:


### PR DESCRIPTION
I've noticed that for `arm64`-only builds the architectures of the Swift libs must contain `armv7`. 
If the arch is not included the build gets rejected similar to  #407. 
Just did an AppStore upload for verification and the processing was successful.