### PR TITLE
Ignore unknown fields from json response

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/appcenter/models/CommitResponse.groovy
+++ b/plugin/src/main/groovy/org/openbakery/appcenter/models/CommitResponse.groovy
@@ -1,6 +1,8 @@
 package org.openbakery.appcenter.models
 
-class CommitResponse {
+class CommitResponse extends Expando {
 	String release_id
 	String release_url
+
+	def propertyMissing(name, value) {}
 }

--- a/plugin/src/main/groovy/org/openbakery/appcenter/models/InitDebugSymbolResponse.groovy
+++ b/plugin/src/main/groovy/org/openbakery/appcenter/models/InitDebugSymbolResponse.groovy
@@ -1,7 +1,9 @@
 package org.openbakery.appcenter.models
 
-class InitDebugSymbolResponse {
+class InitDebugSymbolResponse extends Expando {
 	String symbol_upload_id
 	String upload_url
 	String expiration_date
+
+	def propertyMissing(name, value) {}
 }

--- a/plugin/src/main/groovy/org/openbakery/appcenter/models/InitIpaUploadResponse.groovy
+++ b/plugin/src/main/groovy/org/openbakery/appcenter/models/InitIpaUploadResponse.groovy
@@ -1,6 +1,8 @@
 package org.openbakery.appcenter.models
 
-class InitIpaUploadResponse {
+class InitIpaUploadResponse extends Expando {
 	String upload_id
 	String upload_url
+
+	def propertyMissing(name, value) {}
 }

--- a/plugin/src/test/groovy/org/openbakery/appcenter/AppCenterTaskSpecification.groovy
+++ b/plugin/src/test/groovy/org/openbakery/appcenter/AppCenterTaskSpecification.groovy
@@ -107,6 +107,31 @@ class AppCenterTaskSpecification extends Specification {
 		uploadUrl == expectedUploadUrl
 	}
 
+	def "init IPA Upload with unknown json fields"() {
+		setup:
+		final String expectedUploadId = "1"
+		final String expectedUploadUrl = "https://www.someurl.com/initipaupload"
+
+		JsonBuilder builder = new JsonBuilder()
+		builder {
+			upload_url expectedUploadUrl
+			upload_id expectedUploadId
+			unknownField 'Test'
+		}
+
+		httpUtil.sendJson(HttpUtil.HttpVerb.POST, _, _, _) >> builder.toString()
+
+		String uploadId
+		String uploadUrl
+
+		when:
+		(uploadId, uploadUrl) = appCenterUploadTask.initIpaUpload()
+
+		then:
+		uploadId == expectedUploadId
+		uploadUrl == expectedUploadUrl
+	}
+
 	def "commit Upload"() {
 		setup:
 		final String expectedReleaseId = "2"


### PR DESCRIPTION
The json response of AppCenter has some new fields, which causes the json parsing to fail. This PR ignores all unknown fields in the json response, so that the AppCenter upload will work again.