### PR TITLE
Changes input annotation

### DIFF
--- a/plugin/src/main/groovy/org/openbakery/XcodeTestRunTask.groovy
+++ b/plugin/src/main/groovy/org/openbakery/XcodeTestRunTask.groovy
@@ -3,6 +3,7 @@ package org.openbakery
 import groovy.io.FileType
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
@@ -134,7 +135,7 @@ class XcodeTestRunTask extends AbstractXcodeBuildTask {
 		this.bundleDirectory = bundleDirectory
 	}
 
-	@Input
+	@InputDirectory
 	@Optional
 	File getBundleDirectory() {
 		if (bundleDirectory instanceof File) {


### PR DESCRIPTION
`@Input` on `File` causes a failure during the plugin validation. But I'm not completely sure if `@InputDirectory` fits here.
