### PR TITLE
Removes libxcode and libxcodetools from maven pom for local installs

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -56,9 +56,9 @@ task sourcesJar(type: Jar) {
 }
 
 install {
-    repositories.mavenInstaller {
+	repositories.mavenInstaller {
 		modifyPom(pom)
-    }
+	}
 }
 
 uploadArchives {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -55,6 +55,11 @@ task sourcesJar(type: Jar) {
 	classifier = 'sources'
 }
 
+install {
+    repositories.mavenInstaller {
+		modifyPom(pom)
+    }
+}
 
 uploadArchives {
 	repositories {
@@ -65,11 +70,7 @@ uploadArchives {
 				authentication(userName: publishUser, password: publishPassword)
 			}
 
-			pom.whenConfigured {
-    		p -> p.dependencies = p.dependencies.findAll { 
-        	dep -> dep.artifactId != "libxcode" && dep.artifactId != "libxcodetools"
-    		}
-			}
+			modifyPom(pom)
 
 			pom.project {
 				licenses {
@@ -91,8 +92,13 @@ uploadArchives {
 	}
 }
 
-
-
+def modifyPom(MavenPom pom) {
+	pom.whenConfigured { p -> 
+		p.dependencies = p.dependencies.findAll { dep -> 
+			dep.artifactId != "libxcode" && dep.artifactId != "libxcodetools"
+		}
+	}
+}
 
 pluginBundle {
 	website = 'https://openbakery.org/gxp/'


### PR DESCRIPTION
Recently, there was a change to remove `libxcode` and `libxcodetools` from the maven pom (see e53b63054519a97633ed9fda095f59611646d715). Unfortunately, the change was only done for the `uploadArchives` task but not when installing the plugin locally for debugging. I added the same change to the pom for the `install` task as well.