### PR TITLE
PackageTask xcodebuild parameters set 

### DIFF
--- a/xcode-plugin/src/main/groovy/org/openbakery/packaging/PackageTask.groovy
+++ b/xcode-plugin/src/main/groovy/org/openbakery/packaging/PackageTask.groovy
@@ -112,7 +112,7 @@ class PackageTask extends AbstractDistributeTask {
 		codesignParameters.type = project.xcodebuild.type
 		codesignParameters.keychain = project.xcodebuild.signing.keychainPathInternal
 
-		Xcodebuild xcodebuild = new Xcodebuild(project.projectDir, commandRunner, xcode, new XcodebuildParameters())
+		Xcodebuild xcodebuild = new Xcodebuild(project.projectDir, commandRunner, xcode, project.xcodebuild.xcodebuildParameters)
 		CommandLineTools tools = new CommandLineTools(commandRunner, plistHelper, new Lipo(xcodebuild))
 		Codesign codesign = new Codesign(xcode, codesignParameters, tools.commandRunner, tools.plistHelper)
 		AppPackage appPackage = new AppPackage(applicationBundle, getArchiveDirectory(), tools, codesign)


### PR DESCRIPTION
PackageTask must give the project xcodebuildParameters to the XcodeBuild instance instead of creating new default params. 