### PR TITLE
Add possibility to also package symbols within ipa

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 allprojects {
 	apply plugin: 'java-gradle-plugin'
 	apply plugin: 'groovy'
+	apply plugin: "maven"
 
 	def versionNumber = "0.22.1"
 
@@ -63,11 +64,9 @@ if (project.hasProperty("publish")) {
 project(':xcode-plugin') {
 	dependencies {
 		if (!publish) {
-			println("USE IMPLEMENTATION")
 			implementation project(':libxcode')
 			implementation project(':libxcodetools')
 		} else {
-			println "PUBLISH"
 			compileOnly project(':libxcode')
 			compileOnly project(':libxcodetools')
 		}

--- a/libtest/src/main/groovy/org/openbakery/test/ApplicationDummy.groovy
+++ b/libtest/src/main/groovy/org/openbakery/test/ApplicationDummy.groovy
@@ -187,6 +187,10 @@ class ApplicationDummy {
 	void createDsyms() {
 		File dSymDirectory = new File(applicationBundle.parentFile, "Example.app.dSym")
 		dSymDirectory.mkdirs()
+		File testDysms = new File(directory, "dSYMs")
+		testDysms.mkdirs()
+		File dsyms = new File(testDysms.absolutePath, "Example.app.dSYM")
+		dsyms.mkdirs()
 	}
 
 	void createDsyms(Extension extension) {

--- a/libxcodetools/src/main/kotlin/org/openbakery/assemble/AppPackage.kt
+++ b/libxcodetools/src/main/kotlin/org/openbakery/assemble/AppPackage.kt
@@ -135,8 +135,8 @@ class AppPackage(
 		if (dSymPath.exists()) {
 			logger.debug("Adding Symbols..")
 			tools.commandRunner.run("mkdir", "-p", "${applicationBundle.baseDirectory.absolutePath}/Symbols")
-			println(dSymPath.listFiles({ _, name -> name.endsWith(".dSYM")}).orEmpty().map { it.absolutePath })
-			for (dsym in dSymPath.listFiles({ _, name -> name.endsWith(".dSYM")}).orEmpty()) {
+			println(dSymPath.listFiles { _, name -> name.endsWith(".dSYM") }.orEmpty().map { it.absolutePath })
+			for (dsym in dSymPath.listFiles { _, name -> name.endsWith(".dSYM") }.orEmpty()) {
 				tools.commandRunner.run(
 					"xcrun",
 					"symbols",
@@ -151,7 +151,7 @@ class AppPackage(
 			}
 
 		} else {
-			logger.debug("Tried adding Symbols, but archive does not contain dSYMs to generate them.")
+			throw IllegalStateException("Tried adding Symbols, but archive does not contain dSYMs to generate them in ${dSymPath.absolutePath}.")
 		}
 
 	}

--- a/libxcodetools/src/main/kotlin/org/openbakery/assemble/AppPackage.kt
+++ b/libxcodetools/src/main/kotlin/org/openbakery/assemble/AppPackage.kt
@@ -135,8 +135,14 @@ class AppPackage(
 		if (dSymPath.exists()) {
 			logger.debug("Adding Symbols..")
 			tools.commandRunner.run("mkdir", "-p", "${applicationBundle.baseDirectory.absolutePath}/Symbols")
-			println(dSymPath.listFiles { _, name -> name.endsWith(".dSYM") }.orEmpty().map { it.absolutePath })
-			for (dsym in dSymPath.listFiles { _, name -> name.endsWith(".dSYM") }.orEmpty()) {
+
+			val dsyms = dSymPath.listFiles { _, name -> name.endsWith(".dSYM") }.orEmpty()
+			val bundleNames = dsyms.map { it.name.substringBefore(".")}
+			val dwarfs = dsyms.zip(bundleNames).map { pair -> File(pair.first.absolutePath, "Contents/Resources/DWARF/${pair.second}") }
+
+			logger.info("Found dSYMs at paths: ${dwarfs.map { it.absolutePath }}")
+
+			for (dsym in dwarfs) {
 				tools.commandRunner.run(
 					"xcrun",
 					"symbols",

--- a/xcode-plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
+++ b/xcode-plugin/src/main/groovy/org/openbakery/XcodePlugin.groovy
@@ -52,6 +52,7 @@ import org.openbakery.deploygate.DeployGatePluginExtension
 import org.openbakery.deploygate.DeployGateUploadTask
 import org.openbakery.oclint.OCLintPluginExtension
 import org.openbakery.oclint.OCLintTask
+import org.openbakery.packaging.PackagePluginExtension
 import org.openbakery.signing.KeychainCleanupTask
 import org.openbakery.signing.KeychainCreateTask
 import org.openbakery.packaging.PackageTask
@@ -258,6 +259,9 @@ class XcodePlugin implements Plugin<Project> {
 			if (project.hasProperty('xcodebuild.signing.timeout')) {
 				project.xcodebuild.signing.timeout = project['signing.timeout']
 			}
+			if (project.hasProperty('packaging.packageSymbols')) {
+				project.package.packageSymbols = project['packaging.packageSymbols']
+			}
 
 			if (project.hasProperty('xcodebuild.additionalParameters')) {
 				project.xcodebuild.additionalParameters = project['xcodebuild.additionalParameters']
@@ -432,6 +436,7 @@ class XcodePlugin implements Plugin<Project> {
 		project.extensions.create("oclint", OCLintPluginExtension, project)
 		project.extensions.create("carthage", CarthagePluginExtension, project)
 		project.extensions.create("appcenter", AppCenterPluginExtension, project)
+		project.extensions.create("packaging", PackagePluginExtension, project)
 	}
 
 

--- a/xcode-plugin/src/main/groovy/org/openbakery/packaging/PackagePluginExtension.groovy
+++ b/xcode-plugin/src/main/groovy/org/openbakery/packaging/PackagePluginExtension.groovy
@@ -3,7 +3,7 @@ package org.openbakery.packaging
 import org.gradle.api.Project
 
 class PackagePluginExtension {
-	boolean packageSymbols
+	boolean packageSymbols = true
 
 	private final Project project
 

--- a/xcode-plugin/src/main/groovy/org/openbakery/packaging/PackagePluginExtension.groovy
+++ b/xcode-plugin/src/main/groovy/org/openbakery/packaging/PackagePluginExtension.groovy
@@ -1,0 +1,13 @@
+package org.openbakery.packaging
+
+import org.gradle.api.Project
+
+class PackagePluginExtension {
+	boolean packageSymbols
+
+	private final Project project
+
+	PackagePluginExtension(Project project) {
+		this.project = project
+	}
+}

--- a/xcode-plugin/src/main/groovy/org/openbakery/packaging/PackageTask.groovy
+++ b/xcode-plugin/src/main/groovy/org/openbakery/packaging/PackageTask.groovy
@@ -120,6 +120,12 @@ class PackageTask extends AbstractDistributeTask {
 		appPackage.addSwiftSupport()
 		appPackage.prepareBundles()
 
+		if (project.packaging.packageSymbols) {
+			appPackage.addSymbols()
+		} else {
+			logger.info("No symbols will be added to package because include symbols is not set")
+		}
+
 		if (signSettingsAvailable) {
 			appPackage.codesign()
 		} else {

--- a/xcode-plugin/src/test/groovy/org/openbakery/packaging/PackageTaskSpecification.groovy
+++ b/xcode-plugin/src/test/groovy/org/openbakery/packaging/PackageTaskSpecification.groovy
@@ -84,7 +84,7 @@ class PackageTaskSpecification extends Specification {
 		keychain.delete()
 	}
 
-	void mockExampleApp(boolean withPlugin, boolean withSwift, boolean adHoc = true, boolean withFramework = false, boolean bitcode = false) {
+	void mockExampleApp(boolean withPlugin, boolean withSwift, boolean adHoc = true, boolean withFramework = false, boolean bitcode = false, boolean withDSYMs = true) {
 		outputPath = new File(project.getBuildDir(), packageTask.PACKAGE_PATH)
 
 		archiveDirectory = new File(project.getBuildDir(), XcodeBuildArchiveTask.ARCHIVE_FOLDER + "/Example.xcarchive")
@@ -114,6 +114,10 @@ class PackageTaskSpecification extends Specification {
 
 		if (withFramework) {
 			applicationDummy.createFramework()
+		}
+
+		if (withDSYMs) {
+			applicationDummy.createDsyms()
 		}
 
 		for (File mobileProvision in applicationDummy.mobileProvisionFile) {
@@ -278,11 +282,9 @@ class PackageTaskSpecification extends Specification {
 	def "test symbols"() {
 		given:
 		mockExampleApp(false, false)
-		applicationDummy.createDsyms()
 		File symbolsDir = new File(outputPath.absolutePath, "Symbols")
 
 		when:
-		project.packaging.packageSymbols = true
 		packageTask.packageApplication()
 
 		then:

--- a/xcode-plugin/src/test/groovy/org/openbakery/packaging/PackageTaskSpecification.groovy
+++ b/xcode-plugin/src/test/groovy/org/openbakery/packaging/PackageTaskSpecification.groovy
@@ -301,7 +301,7 @@ class PackageTaskSpecification extends Specification {
 			"all",
 			"--symbolsPackageDir",
 			"${outputPath}/Symbols",
-			new File(dSYMPath, "dSYMs/Example.app.dSYM").absolutePath
+			new File(dSYMPath, "dSYMs/Example.app.dSYM/Contents/Resources/DWARF/Example").absolutePath
 		]
 	}
 

--- a/xcode-plugin/src/test/groovy/org/openbakery/packaging/PackageTaskSpecification.groovy
+++ b/xcode-plugin/src/test/groovy/org/openbakery/packaging/PackageTaskSpecification.groovy
@@ -275,6 +275,36 @@ class PackageTaskSpecification extends Specification {
 		payloadDirectory.exists()
 	}
 
+	def "test symbols"() {
+		given:
+		mockExampleApp(false, false)
+		applicationDummy.createDsyms()
+		File symbolsDir = new File(outputPath.absolutePath, "Symbols")
+
+		when:
+		project.packaging.packageSymbols = true
+		packageTask.packageApplication()
+
+		then:
+		1 * commandRunner.run(["mkdir", "-p", "${outputPath.absolutePath}/Symbols"]) >> { symbolsDir.mkdirs() }
+		1 * commandRunner.run(symbolsCommandList(outputPath.absolutePath, archiveDirectory.absolutePath))
+		symbolsDir.exists()
+	}
+
+	List<String> symbolsCommandList(String outputPath, String dSYMPath) {
+		[
+			"xcrun",
+			"symbols",
+			"-noTextInSOD",
+			"-noDaemon",
+			"--arch",
+			"all",
+			"--symbolsPackageDir",
+			"${outputPath}/Symbols",
+			new File(dSYMPath, "dSYMs/Example.app.dSYM").absolutePath
+		]
+	}
+
 
 	def "test copy app"() {
 		given:


### PR DESCRIPTION
If you like to also package symbols within your ipa, you can do this now via

```gradle
packaging {
  packageSymbols = true
}
```
This should resolve https://github.com/openbakery/gradle-xcodePlugin/issues/454

I am not sure if target should be develop or main, feel free to change